### PR TITLE
Fix bidi surrogate handling, ctx.font caching, emoji correction, and cleanup

### DIFF
--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -362,7 +362,7 @@ function mergeUrlLikeRuns(segmentation: MergedSegmentation): MergedSegmentation 
   const starts = segmentation.starts.slice()
 
   for (let i = 0; i < segmentation.len; i++) {
-    if (kinds[i] !== 'text' || !isUrlLikeRunStart(segmentation, i)) continue
+    if (texts[i]!.length === 0 || kinds[i] !== 'text' || !isUrlLikeRunStart(segmentation, i)) continue
 
     let j = i + 1
     while (j < segmentation.len && kinds[j] !== 'space' && kinds[j] !== 'zero-width-break') {
@@ -699,10 +699,8 @@ function mergeGlueConnectedTextRuns(segmentation: MergedSegmentation): MergedSeg
 }
 
 function carryTrailingForwardStickyAcrossCJKBoundary(segmentation: MergedSegmentation): MergedSegmentation {
-  const texts = segmentation.texts.slice()
-  const isWordLike = segmentation.isWordLike.slice()
-  const kinds = segmentation.kinds.slice()
-  const starts = segmentation.starts.slice()
+  // Mutate in-place — array length is unchanged and the input is not referenced again.
+  const { texts, starts, kinds } = segmentation
 
   for (let i = 0; i < texts.length - 1; i++) {
     if (kinds[i] !== 'text' || kinds[i + 1] !== 'text') continue
@@ -716,13 +714,7 @@ function carryTrailingForwardStickyAcrossCJKBoundary(segmentation: MergedSegment
     starts[i + 1] = starts[i]! + split.head.length
   }
 
-  return {
-    len: texts.length,
-    texts,
-    isWordLike,
-    kinds,
-    starts,
-  }
+  return segmentation
 }
 
 

--- a/src/bidi.ts
+++ b/src/bidi.ts
@@ -59,6 +59,10 @@ function classifyChar(charCode: number): BidiType {
   if (0x0590 <= charCode && charCode <= 0x05f4) return 'R'
   if (0x0600 <= charCode && charCode <= 0x06ff) return arabicTypes[charCode & 0xff]!
   if (0x0700 <= charCode && charCode <= 0x08AC) return 'AL'
+  // Astral RTL/AL ranges (supplementary plane)
+  if (0x10800 <= charCode && charCode <= 0x10FFF) return 'R'
+  if (0x1E800 <= charCode && charCode <= 0x1EDFF) return 'R'
+  if (0x1EE00 <= charCode && charCode <= 0x1EEFF) return 'AL'
   return 'L'
 }
 
@@ -71,9 +75,15 @@ function computeBidiLevels(str: string): Int8Array | null {
   let numBidi = 0
 
   for (let i = 0; i < len; i++) {
-    const t = classifyChar(str.charCodeAt(i))
+    const code = str.codePointAt(i)!
+    const t = classifyChar(code)
     if (t === 'R' || t === 'AL' || t === 'AN') numBidi++
     types[i] = t
+    // Surrogate pair: assign same bidi type to both code units
+    if (code > 0xFFFF) {
+      i++
+      types[i] = t
+    }
   }
 
   if (numBidi === 0) return null

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -406,6 +406,16 @@ describe('layout invariants', () => {
     expect(result.lines.map(line => line.text).join('')).toBe('According to محمد الأحمد, the results improved.')
   })
 
+  test('astral RTL characters produce bidi metadata on the rich path', () => {
+    // U+1E900 Adlam Capital Letter Alif — supplementary-plane RTL script
+    const prepared = prepareWithSegments('Hello \u{1E900}\u{1E922}\u{1E923}\u{1E921}\u{1E924} world', FONT)
+    expect(prepared.segLevels).not.toBeNull()
+
+    const result = layoutWithLines(prepared, 200, LINE_HEIGHT)
+    expect(result.lineCount).toBeGreaterThanOrEqual(1)
+    expect(result.lines.map(line => line.text).join('')).toBe('Hello \u{1E900}\u{1E922}\u{1E923}\u{1E921}\u{1E924} world')
+  })
+
   test('layoutNextLine reproduces layoutWithLines exactly', () => {
     const prepared = prepareWithSegments('foo trans\u00ADatlantic said "hello" to 世界 and waved.', FONT)
     const width = prepared.widths[0]! + prepared.widths[1]! + prepared.widths[2]! + prepared.breakableWidths[4]![0]! + prepared.discretionaryHyphenWidth + 0.1

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -53,6 +53,7 @@ import {
   getSegmentGraphemePrefixWidths,
   getSegmentGraphemeWidths,
   getSegmentMetrics,
+  getSharedGraphemeSegmenter,
   textMayContainEmoji,
 } from './measurement.ts'
 import {
@@ -62,17 +63,9 @@ import {
   type InternalLayoutLine,
 } from './line-break.ts'
 
-let sharedGraphemeSegmenter: Intl.Segmenter | null = null
 // Rich-path only. Reuses grapheme splits while materializing multiple lines
 // from the same prepared handle, without pushing that cache into the API.
 let sharedLineTextCaches = new WeakMap<PreparedTextWithSegments, Map<number, string[]>>()
-
-function getSharedGraphemeSegmenter(): Intl.Segmenter {
-  if (sharedGraphemeSegmenter === null) {
-    sharedGraphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
-  }
-  return sharedGraphemeSegmenter
-}
 
 // --- Public types ---
 
@@ -551,7 +544,6 @@ export function layoutWithLines(prepared: PreparedTextWithSegments, maxWidth: nu
 
 export function clearCache(): void {
   clearAnalysisCaches()
-  sharedGraphemeSegmenter = null
   sharedLineTextCaches = new WeakMap<PreparedTextWithSegments, Map<number, string[]>>()
   clearMeasurementCaches()
 }

--- a/src/line-break.ts
+++ b/src/line-break.ts
@@ -268,7 +268,7 @@ export function walkPreparedLines(
   }
 
   function continueSoftHyphenBreakableSegment(segmentIndex: number): boolean {
-    const gWidths = breakableWidths[segmentIndex]!
+    const gWidths = breakableWidths[segmentIndex] ?? null
     if (gWidths === null) return false
     const fitWidths = engineProfile.preferPrefixWidthsForBreakableRuns
       ? breakablePrefixWidths[segmentIndex] ?? gWidths

--- a/src/line-break.ts
+++ b/src/line-break.ts
@@ -86,6 +86,9 @@ export function normalizeLineStart(
   return { segmentIndex, graphemeIndex: 0 }
 }
 
+// Specialized hot-path counter that mirrors walkPreparedLines break semantics
+// without tracking cursors/widths. Must stay aligned — see layout.test.ts
+// "countPreparedLines stays aligned with the walked line counter".
 export function countPreparedLines(prepared: PreparedLineBreakData, maxWidth: number): number {
   const { widths, kinds, breakableWidths, breakablePrefixWidths } = prepared
   if (widths.length === 0) return 0

--- a/src/measure-harfbuzz.ts
+++ b/src/measure-harfbuzz.ts
@@ -23,6 +23,7 @@ export async function init(): Promise<void> {
 export function loadFont(name: string, path: string): void {
   if (hb === null) throw new Error('Call init() first')
   if (fonts.has(name)) return
+  // Node/Bun only — bundlers targeting browsers should exclude this module.
   const data = require('fs').readFileSync(path) as Buffer
   const blob = hb.createBlob(new Uint8Array(data))
   const face = hb.createFace(blob, 0)

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -18,6 +18,8 @@ export type EngineProfile = {
 let measureContext: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null = null
 const segmentMetricCaches = new Map<string, Map<string, SegmentMetrics>>()
 let cachedEngineProfile: EngineProfile | null = null
+let lastContextFont: string | null = null
+const warnedFonts = new Set<string>()
 
 const emojiPresentationRe = /\p{Emoji_Presentation}/u
 const maybeEmojiRe = /[\p{Emoji_Presentation}\p{Extended_Pictographic}\p{Regional_Indicator}\uFE0F\u20E3]/u
@@ -102,10 +104,15 @@ export function getEngineProfile(): EngineProfile {
 
 export function parseFontSize(font: string): number {
   const m = font.match(/(\d+(?:\.\d+)?)\s*px/)
-  return m ? parseFloat(m[1]!) : 16
+  if (m) return parseFloat(m[1]!)
+  if (!warnedFonts.has(font) && typeof console !== 'undefined') {
+    warnedFonts.add(font)
+    console.warn('pretext: no px size in font "' + font + '"; emoji correction may be inaccurate')
+  }
+  return 16
 }
 
-function getSharedGraphemeSegmenter(): Intl.Segmenter {
+export function getSharedGraphemeSegmenter(): Intl.Segmenter {
   if (sharedGraphemeSegmenter === null) {
     sharedGraphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
   }
@@ -121,15 +128,19 @@ export function textMayContainEmoji(text: string): boolean {
 }
 
 function getEmojiCorrection(font: string, fontSize: number): number {
-  let correction = emojiCorrectionCache.get(font)
-  if (correction !== undefined) return correction
+  const cached = emojiCorrectionCache.get(font)
+  if (cached !== undefined) return cached
 
   const ctx = getMeasureContext()
-  ctx.font = font
+  if (lastContextFont !== font) {
+    ctx.font = font
+    lastContextFont = font
+  }
   const canvasW = ctx.measureText('\u{1F600}').width
-  correction = 0
+  let correction = 0
+  const inflationDetected = canvasW > fontSize + 0.5
   if (
-    canvasW > fontSize + 0.5 &&
+    inflationDetected &&
     typeof document !== 'undefined' &&
     document.body !== null
   ) {
@@ -146,7 +157,12 @@ function getEmojiCorrection(font: string, fontSize: number): number {
       correction = canvasW - domW
     }
   }
-  emojiCorrectionCache.set(font, correction)
+  // Only cache if the comparison completed or no inflation was detected.
+  // If body was null when inflation was detected, skip caching so we retry
+  // once document.body becomes available.
+  if (!inflationDetected || (typeof document !== 'undefined' && document.body !== null)) {
+    emojiCorrectionCache.set(font, correction)
+  }
   return correction
 }
 
@@ -217,7 +233,10 @@ export function getFontMeasurementState(font: string, needsEmojiCorrection: bool
   emojiCorrection: number
 } {
   const ctx = getMeasureContext()
-  ctx.font = font
+  if (lastContextFont !== font) {
+    ctx.font = font
+    lastContextFont = font
+  }
   const cache = getSegmentMetricCache(font)
   const fontSize = parseFontSize(font)
   const emojiCorrection = needsEmojiCorrection ? getEmojiCorrection(font, fontSize) : 0
@@ -228,4 +247,6 @@ export function clearMeasurementCaches(): void {
   segmentMetricCaches.clear()
   emojiCorrectionCache.clear()
   sharedGraphemeSegmenter = null
+  lastContextFont = null
+  warnedFonts.clear()
 }

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -249,4 +249,5 @@ export function clearMeasurementCaches(): void {
   sharedGraphemeSegmenter = null
   lastContextFont = null
   warnedFonts.clear()
+  cachedEngineProfile = null
 }


### PR DESCRIPTION
## Summary
- **Fix astral codepoint misclassification in bidi**: `charCodeAt` only sees surrogate halves — switched to `codePointAt` and extended `classifyChar` for supplementary RTL/AL ranges (U+10800–10FFF, U+1E800–1EDFF, U+1EE00–1EEFF)
- **Cache `ctx.font` assignment**: skip redundant browser font-string parsing when the font hasn't changed between calls
- **Fix emoji correction retry**: don't cache a zero correction when `document.body` was null — retry once body becomes available
- **Warn on non-px font sizes**: `parseFontSize` now warns once per font when falling back to 16px default
- **Unify duplicate grapheme segmenters**: layout.ts and measurement.ts shared identical `Intl.Segmenter` singletons — consolidated into one export
- **Guard `mergeUrlLikeRuns`**: skip already-absorbed segments to prevent double-processing edge case
- **In-place mutation for `carryTrailingForwardStickyAcrossCJKBoundary`**: eliminates 4 array copies (length is unchanged, input is not reused)
- **Add alignment comment on `countPreparedLines`**: documents dual-implementation contract with `walkPreparedLines`
- **Add bundler note on `measure-harfbuzz.ts`**: flags `require('fs')` for browser-targeting bundlers

## Test plan
- [x] `bun test` — 44/44 pass, 99 expect() calls
- [x] `bun run check` — typecheck + lint clean (0 warnings, 0 errors)
- [ ] Browser accuracy sweep (`bun run accuracy-check`) to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)