### PR TITLE
fix(demo): text deselection in demos by skipping unchanged textContent writes

### DIFF
--- a/pages/demos/dynamic-layout.ts
+++ b/pages/demos/dynamic-layout.ts
@@ -344,7 +344,7 @@ function projectHeadlineLines(lines: PositionedLine[], font: string, lineHeight:
   for (let index = 0; index < lines.length; index++) {
     const line = lines[index]!
     const element = domCache.headlineLines[index]!
-    element.textContent = line.text
+    if (element.textContent !== line.text) element.textContent = line.text
     element.style.left = `${line.x}px`
     element.style.top = `${line.y}px`
     element.style.font = font
@@ -357,7 +357,7 @@ function projectBodyLines(lines: PositionedLine[], className: string, font: stri
     const line = lines[offset]!
     const element = domCache.bodyLines[startIndex + offset]!
     element.className = className
-    element.textContent = line.text
+    if (element.textContent !== line.text) element.textContent = line.text
     element.title = ''
     element.style.left = `${line.x}px`
     element.style.top = `${line.y}px`

--- a/pages/demos/editorial-engine.ts
+++ b/pages/demos/editorial-engine.ts
@@ -811,7 +811,7 @@ function render(now: number): boolean {
   for (let index = 0; index < headlineLines.length; index++) {
     const element = domCache.headlineLines[index]!
     const line = headlineLines[index]!
-    element.textContent = line.text
+    if (element.textContent !== line.text) element.textContent = line.text
     element.style.left = `${gutter}px`
     element.style.top = `${gutter + line.y}px`
     element.style.font = headlineFont
@@ -825,7 +825,7 @@ function render(now: number): boolean {
   for (let index = 0; index < allBodyLines.length; index++) {
     const element = domCache.bodyLines[index]!
     const line = allBodyLines[index]!
-    element.textContent = line.text
+    if (element.textContent !== line.text) element.textContent = line.text
     element.style.left = `${line.x}px`
     element.style.top = `${line.y}px`
     element.style.font = BODY_FONT
@@ -847,7 +847,7 @@ function render(now: number): boolean {
     for (let lineIndex = 0; lineIndex < pullquote.lines.length; lineIndex++) {
       const element = domCache.pullquoteLines[pullquoteLineIndex]!
       const line = pullquote.lines[lineIndex]!
-      element.textContent = line.text
+      if (element.textContent !== line.text) element.textContent = line.text
       element.style.left = `${line.x}px`
       element.style.top = `${line.y}px`
       element.style.font = PQ_FONT


### PR DESCRIPTION
# Before

https://github.com/user-attachments/assets/f1cbc51d-b751-49ff-9ef2-51dae7f5392d

# After

https://github.com/user-attachments/assets/dc6227ba-cef1-4f0c-b01b-4aa75f04cf91

