### PR TITLE
docs: add integration tips to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ Pretext doesn't try to be a full font rendering engine (yet?). It currently targ
 - `system-ui` is unsafe for `layout()` accuracy on macOS. Use a named font.
 - Because the default target includes `overflow-wrap: break-word`, very narrow widths can still break inside words, but only at grapheme boundaries.
 
+## Integration Tips
+
+- `prepare()` is the one-time expensive step. `layout()` is the cheap hot path. Re-run `prepare()` when the text or font changes, not on every resize, and keep the `font` / `lineHeight` you pass synced with the CSS `font` / `line-height` used for that text.
+- Start with `prepare()` + `layout()` for height prediction and resize handling. Switch to `prepareWithSegments()` and the rich line APIs only when you need actual line contents or manual layout behavior.
+
 ## Develop
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for the dev setup and commands.


### PR DESCRIPTION

## Summary

Adds a very small `README.md` section with practical integration tips for Pretext.

The README already covers the API surface and examples well. This keeps the scope narrow and only highlights two integration rules that are easy to miss when wiring the library into app code:

- treat `prepare()` as the one-time expensive step and `layout()` as the resize-time hot path
- start with `prepare()` + `layout()` for height prediction, and only switch to `prepareWithSegments()` and the rich line APIs when actual line contents or manual layout behavior are needed

## Why

There seems to be room for a tiny integration-oriented addition alongside the current API overview, especially around the main prepare-time vs layout-time mental model.

## Scope

- updates `README.md` only
- does not change runtime behavior or public API