### PR TITLE
perf: Replace Array.from with new Array in measureAnalysis

### DIFF
--- a/src/layout.ts
+++ b/src/layout.ts
@@ -214,8 +214,8 @@ function measureAnalysis(
   const breakableWidths: (number[] | null)[] = []
   const breakablePrefixWidths: (number[] | null)[] = []
   const segments = includeSegments ? [] as string[] : null
-  const preparedStartByAnalysisIndex = Array.from<number>({ length: analysis.len })
-  const preparedEndByAnalysisIndex = Array.from<number>({ length: analysis.len })
+  const preparedStartByAnalysisIndex = new Array<number>(analysis.len)
+  const preparedEndByAnalysisIndex = new Array<number>(analysis.len)
 
   function pushMeasuredSegment(
     text: string,


### PR DESCRIPTION
Replaces `Array.from<number>({ length: N })` with `new Array<number>(N)` for two temporary arrays in `measureAnalysis()`. Both are immediately populated by index assignment, so the `Array.from` iterator overhead is pure waste.

`Array.from({ length: N })` loops N times to fill the array with `undefined`, then we overwrite every slot anyway. `new Array(N)` just creates the array directly — no unnecessary loop.

### Benchmark

- https://jsperf.app/xidefu
- https://jsperf.app/xidefu/2