### PR TITLE
perf: Fast-path splitSegmentByBreakKind for pure-text segments

### DIFF
--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -333,12 +333,18 @@ function classifySegmentBreakChar(ch: string, whiteSpaceProfile: WhiteSpaceProfi
   return 'text'
 }
 
+// All characters that classifySegmentBreakChar maps to a non-'text' kind.
+const breakCharRe = /[\x20\t\n\xA0\xAD\u200B\u202F\u2060\uFEFF]/
+
 function splitSegmentByBreakKind(
   segment: string,
   isWordLike: boolean,
   start: number,
   whiteSpaceProfile: WhiteSpaceProfile,
 ): SegmentationPiece[] {
+  if (!breakCharRe.test(segment)) {
+    return [{ text: segment, isWordLike, kind: 'text', start }]
+  }
   const pieces: SegmentationPiece[] = []
   let currentKind: SegmentBreakKind | null = null
   let currentText = ''


### PR DESCRIPTION
### What

`splitSegmentByBreakKind` is called for every segment produced by `Intl.Segmenter` during `prepare()`. It iterates each character with `for...of`, classifies it via `classifySegmentBreakChar`, and groups consecutive characters of the same kind into pieces.

For the vast majority of segments — normal text words like `"hello"`, `"world"`, `"المكتبة"` — every character classifies as `text`, producing a single piece. The per-character loop, string concatenation (`currentText += ch`), and array/object allocation for the pieces list are all unnecessary work in this case.

This PR adds a hoisted regex that matches the 9 characters `classifySegmentBreakChar` maps to non-`text` kinds (space, tab, newline, NBSP, NNBSP, word joiner, BOM, ZWSP, soft hyphen). If the segment doesn't contain any of them, we return a single-element array immediately, skipping the loop entirely.

### Benchmark

Using the project's built-in benchmark page (`/benchmark`), the analysis phase for Arabic text drops from ~29ms to ~12ms, a ~58% improvement.