### PR TITLE
feat: add MCP server for AI-assisted text measurement

### DIFF
--- a/mcp-server/.gitignore
+++ b/mcp-server/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,77 @@
+# Pretext MCP Server
+
+[MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that exposes Pretext's text measurement and layout as tools for AI coding assistants like Claude Code, Cursor, or any MCP-compatible client.
+
+This gives AI assistants the ability to **measure text layout** without a browser — verifying that labels fit in buttons, computing paragraph heights for virtualization, and validating UI text at development time.
+
+## Tools
+
+| Tool | Description |
+|---|---|
+| `measure_text` | Measure paragraph height and line count at a given width |
+| `layout_lines` | Get individual line text/width for rendering or debugging |
+| `find_optimal_width` | Binary search for minimum width fitting N lines (shrink-wrap) |
+| `validate_text_fit` | Batch check that multiple texts fit within constraints |
+| `clear_cache` | Clear internal measurement caches |
+
+## Setup
+
+### With Claude Code
+
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "pretext": {
+      "command": "node",
+      "args": ["/path/to/pretext/mcp-server/dist/index.js"]
+    }
+  }
+}
+```
+
+### With any MCP client
+
+```bash
+cd mcp-server
+npm install
+npm run build
+node dist/index.js  # Communicates via stdio
+```
+
+## Requirements
+
+- Node.js >= 18
+- System fonts (the server loads fonts from your OS font directory automatically)
+
+## How it works
+
+Pretext normally runs in a browser where `OffscreenCanvas` or `<canvas>` provides text measurement via `measureText()`. This server polyfills `OffscreenCanvas` using `@napi-rs/canvas` (Skia-based, no native dependencies to install), allowing Pretext to run headlessly in Node.js.
+
+System fonts are loaded automatically:
+- **Windows**: `C:\Windows\Fonts`
+- **macOS**: `/System/Library/Fonts`, `/Library/Fonts`
+- **Linux**: `/usr/share/fonts`, `/usr/local/share/fonts`
+
+You can also place `.ttf`/`.otf` files in the `fonts/` directory next to the server.
+
+## Example usage from Claude Code
+
+Once configured, Claude Code can call these tools directly:
+
+```
+> measure_text("Submit Order", "14px Arial", maxWidth=120, lineHeight=18)
+→ { lineCount: 1, height: 18 }
+
+> validate_text_fit([
+    { id: "btn", text: "Submit", font: "14px Arial", maxWidth: 80, lineHeight: 18 },
+    { id: "label", text: "Very long label text...", font: "14px Arial", maxWidth: 80, lineHeight: 18 }
+  ])
+→ { summary: "HAS_FAILURES", passed: 1, failed: 1 }
+```
+
+## Caveats
+
+- Font metrics from `@napi-rs/canvas` (Skia) may differ slightly from browser measurements. Results are close but not pixel-perfect compared to Chrome/Safari/Firefox.
+- `system-ui` font is unreliable — use named fonts like `"16px Arial"` or `"16px Inter"`.

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@chenglou/pretext-mcp",
+  "version": "0.1.0",
+  "description": "MCP server exposing Pretext text measurement and layout tools for AI coding assistants",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "pretext-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@chenglou/pretext": "file:..",
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@napi-rs/canvas": "^0.1.68",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT"
+}

--- a/mcp-server/src/canvas-polyfill.ts
+++ b/mcp-server/src/canvas-polyfill.ts
@@ -1,0 +1,74 @@
+/**
+ * OffscreenCanvas polyfill for Node.js using @napi-rs/canvas.
+ *
+ * Must be imported BEFORE any @chenglou/pretext import so that
+ * pretext's getMeasureContext() finds globalThis.OffscreenCanvas.
+ */
+
+import { Canvas, GlobalFonts } from '@napi-rs/canvas'
+import { existsSync } from 'node:fs'
+import { platform } from 'node:os'
+import { join } from 'node:path'
+
+function loadSystemFonts(): void {
+  const os = platform()
+  const dirs: string[] = []
+
+  if (os === 'win32') {
+    dirs.push('C:\\Windows\\Fonts')
+  } else if (os === 'darwin') {
+    dirs.push('/System/Library/Fonts')
+    dirs.push('/Library/Fonts')
+  } else {
+    dirs.push('/usr/share/fonts')
+    dirs.push('/usr/local/share/fonts')
+  }
+
+  // Also check for bundled fonts next to the package
+  const bundledDir = join(import.meta.dirname ?? '.', '..', 'fonts')
+  if (existsSync(bundledDir)) {
+    dirs.push(bundledDir)
+  }
+
+  for (const dir of dirs) {
+    if (existsSync(dir)) {
+      try {
+        GlobalFonts.loadFontsFromDir(dir)
+      } catch {
+        // Silently skip inaccessible font directories
+      }
+    }
+  }
+}
+
+class OffscreenCanvasPolyfill {
+  private _canvas: Canvas
+
+  constructor(width: number, height: number) {
+    this._canvas = new Canvas(width, height)
+  }
+
+  getContext(type: string) {
+    if (type !== '2d') return null
+    return this._canvas.getContext('2d')
+  }
+
+  get width(): number {
+    return this._canvas.width
+  }
+
+  get height(): number {
+    return this._canvas.height
+  }
+}
+
+export function installPolyfill(): void {
+  if (typeof globalThis.OffscreenCanvas !== 'undefined') return
+
+  loadSystemFonts()
+
+  ;(globalThis as Record<string, unknown>).OffscreenCanvas = OffscreenCanvasPolyfill
+}
+
+// Self-install on import
+installPolyfill()

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+
+/**
+ * Pretext MCP Server
+ *
+ * Exposes @chenglou/pretext text measurement and layout as MCP tools
+ * for AI coding assistants (Claude Code, Cursor, etc.).
+ *
+ * Tools:
+ *   - measure_text: Measure paragraph height and line count at a given width
+ *   - layout_lines: Get individual line text/width for rendering
+ *   - find_optimal_width: Binary search for minimum width fitting N lines
+ *   - validate_text_fit: Batch check that texts fit within constraints
+ */
+
+// Polyfill MUST be first — before any pretext import
+import './canvas-polyfill.js'
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z } from 'zod'
+import {
+  prepare,
+  prepareWithSegments,
+  layout,
+  layoutWithLines,
+  walkLineRanges,
+  clearCache,
+} from '@chenglou/pretext'
+
+const server = new McpServer({
+  name: 'pretext',
+  version: '0.1.0',
+})
+
+// --- Tool: measure_text ---
+
+server.tool(
+  'measure_text',
+  'Measure a paragraph of text to get its height and line count at a given max width. ' +
+    'Uses the same line-breaking algorithm as CSS white-space:normal + overflow-wrap:break-word. ' +
+    'Supports all languages including CJK, Arabic, Thai, mixed bidi, and emoji.',
+  {
+    text: z.string().describe('The text content to measure'),
+    font: z.string().describe('CSS font shorthand, e.g. "16px Inter", "bold 14px Arial"'),
+    maxWidth: z.number().positive().describe('Maximum line width in pixels'),
+    lineHeight: z.number().positive().describe('Line height in pixels (matches CSS line-height)'),
+    whiteSpace: z
+      .enum(['normal', 'pre-wrap'])
+      .optional()
+      .describe('White-space mode. "pre-wrap" preserves spaces, tabs, and newlines'),
+  },
+  async ({ text, font, maxWidth, lineHeight, whiteSpace }) => {
+    const options = whiteSpace ? { whiteSpace } : undefined
+    const prepared = prepare(text, font, options)
+    const result = layout(prepared, maxWidth, lineHeight)
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            lineCount: result.lineCount,
+            height: result.height,
+            maxWidth,
+            lineHeight,
+            font,
+          }),
+        },
+      ],
+    }
+  },
+)
+
+// --- Tool: layout_lines ---
+
+server.tool(
+  'layout_lines',
+  'Lay out text and return individual lines with their text content and measured width. ' +
+    'Useful for canvas/SVG rendering, debugging layout, or verifying line breaks.',
+  {
+    text: z.string().describe('The text content to lay out'),
+    font: z.string().describe('CSS font shorthand, e.g. "16px Inter"'),
+    maxWidth: z.number().positive().describe('Maximum line width in pixels'),
+    lineHeight: z.number().positive().describe('Line height in pixels'),
+    whiteSpace: z
+      .enum(['normal', 'pre-wrap'])
+      .optional()
+      .describe('White-space mode'),
+  },
+  async ({ text, font, maxWidth, lineHeight, whiteSpace }) => {
+    const options = whiteSpace ? { whiteSpace } : undefined
+    const prepared = prepareWithSegments(text, font, options)
+    const result = layoutWithLines(prepared, maxWidth, lineHeight)
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            lineCount: result.lineCount,
+            height: result.height,
+            lines: result.lines.map((line) => ({
+              text: line.text,
+              width: Math.round(line.width * 100) / 100,
+            })),
+          }),
+        },
+      ],
+    }
+  },
+)
+
+// --- Tool: find_optimal_width ---
+
+server.tool(
+  'find_optimal_width',
+  'Find the minimum container width so that text fits within a target number of lines. ' +
+    'Uses binary search over walkLineRanges. Useful for shrink-wrapping text containers.',
+  {
+    text: z.string().describe('The text content'),
+    font: z.string().describe('CSS font shorthand, e.g. "16px Inter"'),
+    lineHeight: z.number().positive().describe('Line height in pixels'),
+    maxLines: z.number().int().positive().describe('Target maximum number of lines'),
+    whiteSpace: z
+      .enum(['normal', 'pre-wrap'])
+      .optional()
+      .describe('White-space mode'),
+  },
+  async ({ text, font, lineHeight, maxLines, whiteSpace }) => {
+    const options = whiteSpace ? { whiteSpace } : undefined
+    const prepared = prepareWithSegments(text, font, options)
+
+    // Find the widest single line to use as upper bound
+    let totalWidth = 0
+    walkLineRanges(prepared, Infinity, (line) => {
+      totalWidth += line.width
+    })
+
+    if (totalWidth === 0) {
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ minWidth: 0, lineCount: 0, height: 0 }) }],
+      }
+    }
+
+    // Binary search for minimum width
+    let lo = 0
+    let hi = totalWidth + 1
+    const tolerance = 0.5 // sub-pixel precision
+
+    while (hi - lo > tolerance) {
+      const mid = (lo + hi) / 2
+      let lineCount = 0
+      walkLineRanges(prepared, mid, () => { lineCount++ })
+      if (lineCount <= maxLines) {
+        hi = mid
+      } else {
+        lo = mid
+      }
+    }
+
+    const minWidth = Math.ceil(hi * 100) / 100
+    const finalResult = layout(prepared, minWidth, lineHeight)
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            minWidth,
+            lineCount: finalResult.lineCount,
+            height: finalResult.height,
+            targetMaxLines: maxLines,
+          }),
+        },
+      ],
+    }
+  },
+)
+
+// --- Tool: validate_text_fit ---
+
+server.tool(
+  'validate_text_fit',
+  'Batch-validate that multiple texts fit within given constraints (max width, max lines, max height). ' +
+    'Returns PASS/FAIL per item. Useful for checking all labels/buttons on a page at once.',
+  {
+    items: z
+      .array(
+        z.object({
+          id: z.string().describe('Identifier for this item (e.g. "submit-button", "header-title")'),
+          text: z.string().describe('Text content to validate'),
+          font: z.string().describe('CSS font shorthand'),
+          maxWidth: z.number().positive().describe('Container width in pixels'),
+          lineHeight: z.number().positive().describe('Line height in pixels'),
+          maxLines: z.number().int().positive().optional().describe('Max allowed lines (default: 1)'),
+          maxHeight: z.number().positive().optional().describe('Max allowed height in pixels'),
+        }),
+      )
+      .describe('Array of text items to validate'),
+  },
+  async ({ items }) => {
+    const results = items.map((item) => {
+      const prepared = prepare(item.text, item.font)
+      const result = layout(prepared, item.maxWidth, item.lineHeight)
+      const maxLines = item.maxLines ?? 1
+      const maxHeight = item.maxHeight ?? maxLines * item.lineHeight
+
+      const linesOk = result.lineCount <= maxLines
+      const heightOk = result.height <= maxHeight + 0.01
+      const pass = linesOk && heightOk
+
+      return {
+        id: item.id,
+        pass,
+        lineCount: result.lineCount,
+        height: result.height,
+        ...(pass
+          ? {}
+          : {
+              reason: !linesOk
+                ? `${result.lineCount} lines exceeds max ${maxLines}`
+                : `height ${result.height}px exceeds max ${maxHeight}px`,
+            }),
+      }
+    })
+
+    const allPass = results.every((r) => r.pass)
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            summary: allPass ? 'ALL_PASS' : 'HAS_FAILURES',
+            passed: results.filter((r) => r.pass).length,
+            failed: results.filter((r) => !r.pass).length,
+            total: results.length,
+            results,
+          }),
+        },
+      ],
+    }
+  },
+)
+
+// --- Tool: clear_cache ---
+
+server.tool(
+  'clear_cache',
+  'Clear Pretext internal caches. Useful if you switch fonts or want fresh measurements.',
+  {},
+  async () => {
+    clearCache()
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify({ cleared: true }) }],
+    }
+  },
+)
+
+// --- Start server ---
+
+async function main() {
+  const transport = new StdioServerTransport()
+  await server.connect(transport)
+}
+
+main().catch((err) => {
+  console.error('Pretext MCP server failed to start:', err)
+  process.exit(1)
+})

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds an **MCP (Model Context Protocol) server** that exposes Pretext's text measurement and layout as tools for AI coding assistants (Claude Code, Cursor, or any MCP-compatible client).

This gives AI tools the ability to **measure text layout without a browser** — verifying that labels fit in buttons, computing paragraph heights for virtualization, and validating UI text at development time.

## Tools exposed

| Tool | Description |
|---|---|
| `measure_text` | Measure paragraph height and line count at a given width |
| `layout_lines` | Get individual line text/width for rendering or debugging |
| `find_optimal_width` | Binary search for minimum width fitting N lines (shrink-wrap) |
| `validate_text_fit` | Batch check that multiple texts fit within constraints |
| `clear_cache` | Clear internal measurement caches |

## How it works

- **OffscreenCanvas polyfill**: Uses `@napi-rs/canvas` (Skia-based, zero native deps to install) to provide `OffscreenCanvas` in Node.js
- **Automatic system font loading**: Detects and loads fonts from the OS font directory (Windows, macOS, Linux)
- **Full i18n support**: CJK, Arabic, Thai, mixed bidi, emoji — all work as in the browser

## Setup (Claude Code example)

```json
{
  "mcpServers": {
    "pretext": {
      "command": "node",
      "args": ["/path/to/pretext/mcp-server/dist/index.js"]
    }
  }
}
```

## Test results

All 5 tools tested end-to-end via stdio JSON-RPC:

```
measure_text("Hello world, this is a test...", "16px Arial", 200, 20)
→ { lineCount: 4, height: 80 }

layout_lines("Hello world, this is a test of Pretext MCP server.", "16px Arial", 200, 20)
→ { lines: [{ text: "Hello world, this is a test of ", width: 190.32 }, { text: "Pretext MCP server.", width: 143.16 }] }

find_optimal_width("AGI 春天到了. بدأت الرحلة 🚀", "18px Arial", 26, maxLines=2)
→ { minWidth: 95.01, lineCount: 2 }

validate_text_fit([{ id: "submit-btn", text: "Submit", ... }, { id: "long-label", text: "Very long label...", ... }])
→ { summary: "HAS_FAILURES", passed: 1, failed: 1 }
```

## Files added

```
mcp-server/
├── .gitignore
├── README.md
├── package.json          # deps: @chenglou/pretext, @modelcontextprotocol/sdk, @napi-rs/canvas, zod
├── tsconfig.json
└── src/
    ├── canvas-polyfill.ts  # OffscreenCanvas polyfill via @napi-rs/canvas
    └── index.ts            # MCP server with 5 tools
```

## Caveats

- Font metrics from `@napi-rs/canvas` (Skia) may differ slightly from browser `measureText()`. Close but not pixel-perfect
- `system-ui` font is unreliable, same as in the browser — use named fonts

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)