### PR TITLE
feat: add `setMeasureFunction` for custom measurement backends

### DIFF
--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -19,6 +19,7 @@ let layoutNextLine: LayoutModule['layoutNextLine']
 let walkLineRanges: LayoutModule['walkLineRanges']
 let clearCache: LayoutModule['clearCache']
 let setLocale: LayoutModule['setLocale']
+let setMeasureFunction: LayoutModule['setMeasureFunction']
 let countPreparedLines: LineBreakModule['countPreparedLines']
 let walkPreparedLines: LineBreakModule['walkPreparedLines']
 
@@ -109,6 +110,7 @@ beforeAll(async () => {
     walkLineRanges,
     clearCache,
     setLocale,
+    setMeasureFunction,
   } = mod)
   ;({ countPreparedLines, walkPreparedLines } = lineBreakMod)
 })
@@ -623,5 +625,39 @@ describe('layout invariants', () => {
         expect(counted).toBe(walked)
       }
     }
+  })
+})
+
+describe('setMeasureFunction', () => {
+  test('custom measure function is used instead of canvas', () => {
+    setMeasureFunction((text: string) => text.length * 10)
+    
+    const prepared = prepareWithSegments('Hello World', FONT)
+    const result = layout(prepared, 80, LINE_HEIGHT)
+
+    expect(result.lineCount).toBe(2)
+    setMeasureFunction(null)
+  })
+
+  test('setting null restores canvas measurement', () => {
+    setMeasureFunction((text: string) => text.length * 10)
+    setMeasureFunction(null)
+
+    const prepared = prepare('Hello World', FONT)
+    const result = layout(prepared, 200, LINE_HEIGHT)
+    expect(result.lineCount).toBe(1)
+  })
+
+  test('caches are cleared when measure function changes', () => {
+    const p1 = prepare('Test', FONT)
+    const r1 = layout(p1, 200, LINE_HEIGHT)
+
+    setMeasureFunction((text: string) => text.length * 100)
+    const p2 = prepare('Test', FONT)
+    const r2 = layout(p2, 200, LINE_HEIGHT)
+
+    expect(r2.lineCount).toBeGreaterThan(r1.lineCount)
+
+    setMeasureFunction(null)
   })
 })

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -55,6 +55,7 @@ import {
   getSegmentGraphemePrefixWidths,
   getSegmentGraphemeWidths,
   getSegmentMetrics,
+  setMeasureFunction,
   textMayContainEmoji,
 } from './measurement.js'
 import {
@@ -715,3 +716,5 @@ export function setLocale(locale?: string): void {
   setAnalysisLocale(locale)
   clearCache()
 }
+
+export { setMeasureFunction }

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -18,11 +18,23 @@ export type EngineProfile = {
 let measureContext: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null = null
 const segmentMetricCaches = new Map<string, Map<string, SegmentMetrics>>()
 let cachedEngineProfile: EngineProfile | null = null
+let customMeasureFn: ((text: string) => number) | null = null
 
 const emojiPresentationRe = /\p{Emoji_Presentation}/u
 const maybeEmojiRe = /[\p{Emoji_Presentation}\p{Extended_Pictographic}\p{Regional_Indicator}\uFE0F\u20E3]/u
 let sharedGraphemeSegmenter: Intl.Segmenter | null = null
 const emojiCorrectionCache = new Map<string, number>()
+
+/**
+ * Register a custom text measurement function for non-browser environments.
+ * When set, all segment measurement bypasses Canvas and uses this function
+ * instead. Set it to null to restore the default Canvas-based measurement.
+ */
+export function setMeasureFunction(fn: ((text: string) => number) | null): void {
+  customMeasureFn = fn
+  clearMeasurementCaches()
+  cachedEngineProfile = null
+}
 
 export function getMeasureContext(): CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D {
   if (measureContext !== null) return measureContext
@@ -52,9 +64,11 @@ export function getSegmentMetricCache(font: string): Map<string, SegmentMetrics>
 export function getSegmentMetrics(seg: string, cache: Map<string, SegmentMetrics>): SegmentMetrics {
   let metrics = cache.get(seg)
   if (metrics === undefined) {
-    const ctx = getMeasureContext()
+    const width = customMeasureFn !== null
+      ? customMeasureFn(seg)
+      : getMeasureContext().measureText(seg).width
     metrics = {
-      width: ctx.measureText(seg).width,
+      width,
       containsCJK: isCJK(seg),
     }
     cache.set(seg, metrics)
@@ -65,7 +79,7 @@ export function getSegmentMetrics(seg: string, cache: Map<string, SegmentMetrics
 export function getEngineProfile(): EngineProfile {
   if (cachedEngineProfile !== null) return cachedEngineProfile
 
-  if (typeof navigator === 'undefined') {
+  if (typeof navigator === 'undefined' || typeof navigator.userAgent !== 'string') {
     cachedEngineProfile = {
       lineFitEpsilon: 0.005,
       carryCJKAfterClosingQuote: false,
@@ -216,11 +230,14 @@ export function getFontMeasurementState(font: string, needsEmojiCorrection: bool
   fontSize: number
   emojiCorrection: number
 } {
-  const ctx = getMeasureContext()
-  ctx.font = font
+  if (customMeasureFn === null) {
+    const ctx = getMeasureContext()
+    ctx.font = font
+  }
   const cache = getSegmentMetricCache(font)
   const fontSize = parseFontSize(font)
-  const emojiCorrection = needsEmojiCorrection ? getEmojiCorrection(font, fontSize) : 0
+  // When a custom measure function is active, it should handle emoji correction if needed
+  const emojiCorrection = customMeasureFn === null && needsEmojiCorrection ? getEmojiCorrection(font, fontSize) : 0
   return { cache, fontSize, emojiCorrection }
 }
 


### PR DESCRIPTION
## Why?

- The idea is borrowed from [Yoga](https://github.com/facebook/yoga) which has a concept of measure function for measureable nodes (`Text`). This allows us to plug pretext into non browser environments like React Native.

## How?

Exported `setMeasureFunction` function which can be used to provide a custom measure function.
- Example of using pretext in React native environment with `@shopify/react-native-skia` and custom native measurement module - https://github.com/intergalacticspacehighway/pretext-react-native-example/

## Test plan
- Added basic JS tests with measure function.
- Test React native example - https://github.com/intergalacticspacehighway/pretext-react-native-example/

## Alternatives

Alternate solution for cross platform would be to polyfill the `OffscreenCanvas`. This also works, can just be documented.

```js
globalThis.OffscreenCanvas = class {
  getContext() {
    let currentFont = '';
    return {
      set font(f: string) { currentFont = f; },
      get font() { return currentFont; },
      measureText(text: string) {
        return { width: MyMeasureFunction() };
      }
    };
  }
};
```

