### PR TITLE
fix: align trailing collapsible space handling across all line-break paths

### DIFF
--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -624,4 +624,37 @@ describe('layout invariants', () => {
       }
     }
   })
+
+  test('trailing collapsible space hangs without breaking across count and walk paths', () => {
+    // Regression test for issue #11: countPreparedLinesSimple (used by layout())
+    // and walkPreparedLinesSimple (used by layoutWithLines()) returned different
+    // lineCount when a trailing collapsible space overflowed the line edge.
+    //
+    // CSS white-space: normal behavior: trailing collapsible whitespace hangs
+    // past the line edge without triggering a line break.
+    //
+    // We craft internal data directly because the fake measurement system's
+    // proportions (space=0.33x, char>=0.4x) can't produce the divergence
+    // condition: word + space > maxWidth but word + nextSegment <= maxWidth.
+    const prepared = {
+      widths: [40, 5, 1],
+      lineEndFitAdvances: [40, 0, 1],
+      lineEndPaintAdvances: [40, 0, 1],
+      kinds: ['text' as const, 'space' as const, 'text' as const],
+      simpleLineWalkFastPath: true,
+      breakableWidths: [null, null, null],
+      breakablePrefixWidths: [null, null, null],
+      discretionaryHyphenWidth: 5,
+      tabStopAdvance: 0,
+      chunks: [{ startSegmentIndex: 0, endSegmentIndex: 3, consumedEndSegmentIndex: 3 }],
+    }
+
+    // 40 + 5 = 45 > 42: space overflows
+    // 40 + 1 = 41 <= 42: next segment fits if space just hangs
+    const maxWidth = 42
+    const counted = countPreparedLines(prepared, maxWidth)
+    const walked = walkPreparedLines(prepared, maxWidth)
+    expect(counted).toBe(1)
+    expect(walked).toBe(counted)
+  })
 })

--- a/src/line-break.ts
+++ b/src/line-break.ts
@@ -333,6 +333,13 @@ function walkPreparedLinesSimple(
 
     const newW = lineW + w
     if (newW > maxWidth + lineFitEpsilon) {
+      // CSS behavior: trailing collapsible space hangs past the line edge
+      // without triggering a line break — matches countPreparedLinesSimple
+      if (isSimpleCollapsibleSpace(kind)) {
+        i++
+        continue
+      }
+
       if (canBreakAfter(kind)) {
         appendWholeSegment(i, w)
         emitCurrentLine(i + 1, 0, lineW - w)
@@ -1029,6 +1036,12 @@ function layoutNextLineRangeSimple(
 
     const newW = lineW + w
     if (newW > maxWidth + lineFitEpsilon) {
+      // CSS behavior: trailing collapsible space hangs past the line edge
+      // without triggering a line break — matches countPreparedLinesSimple
+      if (isSimpleCollapsibleSpace(kind)) {
+        continue
+      }
+
       if (canBreakAfter(kind)) {
         appendWholeSegment(i, w)
         return finishLine(i + 1, 0, lineW - w)


### PR DESCRIPTION
## Summary

Fixes #11 — `layout()` and `layoutWithLines()` return different `lineCount` for trailing collapsible spaces.

`countPreparedLinesSimple` (used by `layout()`) correctly skips collapsible spaces that overflow the line edge — CSS `white-space: normal` behavior where trailing spaces hang without triggering a break. The two walk-path counterparts were missing this guard:

- **`walkPreparedLinesSimple`** (used by `layoutWithLines()` / `walkLineRanges()`) — `canBreakAfter('space')` triggered a spurious line break
- **`layoutNextLineRangeSimple`** (used by `layoutNextLine()`) — same issue

The fix adds the `isSimpleCollapsibleSpace` check before `canBreakAfter` in both paths, matching the count path.

### Reproduction

Any text where `wordWidth + spaceWidth > maxWidth` but `wordWidth + nextSegmentWidth <= maxWidth`:

```ts
// Before fix: layout() -> 1 line, layoutWithLines() -> 2 lines
// After fix:  both -> 1 line (CSS-correct)
```

## Changes

- `src/line-break.ts` — add `isSimpleCollapsibleSpace` guard in `walkPreparedLinesSimple` and `layoutNextLineRangeSimple` (+12 lines)
- `src/layout.test.ts` — regression test with crafted segment data that directly triggers the divergence (+33 lines)

## Test plan

- [x] `bun test` — 61/61 pass (including new regression test)
- [x] `tsc --noEmit` — 0 errors
- [x] `oxlint --type-aware src` — 0 warnings, 0 errors
- [x] Regression verified: reverting the `line-break.ts` fix causes the new test to fail (`walked=2` vs `counted=1`)