### PR TITLE
Add virtual chat demo with side-by-side DOM-layout comparison

### DIFF
--- a/pages/demos/index.html
+++ b/pages/demos/index.html
@@ -136,6 +136,11 @@
         <h2>Masonry</h2>
         <p>A text-card occlusion demo where height prediction comes from Pretext instead of DOM reads.</p>
       </a>
+
+      <a class="card" href="/demos/virtual-chat">
+        <h2>Virtual Chat</h2>
+        <p>5,000 chat messages virtualized with live DOM vs Pretext measurement cost, toggleable with width and font-size sliders.</p>
+      </a>
     </section>
   </main>
 </body>

--- a/pages/demos/virtual-chat.html
+++ b/pages/demos/virtual-chat.html
@@ -8,44 +8,69 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0f0f0f; color: #e0e0e0; height: 100vh; overflow: hidden; display: flex; flex-direction: column; }
 
-.top-bar {
-  display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 12px 24px;
-  background: #1a1a1a; border-bottom: 1px solid #333; padding: 10px 16px; flex-shrink: 0;
-}
-.control { display: flex; align-items: center; gap: 8px; }
-.control label { font-size: 12px; color: #888; }
-.control input[type=range] { width: 110px; accent-color: #666; }
-.control .val { font-size: 12px; color: #ccc; min-width: 36px; font-variant-numeric: tabular-nums; }
+/* --- Controls --- */
 
-/* Toggle switch */
-.toggle { display: flex; align-items: center; gap: 10px; }
-.toggle-label { font-size: 12px; color: #888; text-transform: uppercase; letter-spacing: 0.5px; transition: color 0.2s; }
+.controls {
+  display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 8px 20px;
+  background: #1a1a1a; border-bottom: 1px solid #282828; padding: 10px 16px; flex-shrink: 0;
+}
+
+.toggle { display: flex; align-items: center; gap: 8px; }
+.toggle-label {
+  font-size: 11px; color: #666; text-transform: uppercase; letter-spacing: 0.6px;
+  transition: color 0.2s;
+}
 .toggle-label.active { font-weight: 600; }
 .toggle-label.dom.active { color: #cc8888; }
 .toggle-label.pretext.active { color: #88cc88; }
-.switch { position: relative; width: 44px; height: 24px; cursor: pointer; flex-shrink: 0; }
+
+.switch { position: relative; width: 40px; height: 22px; cursor: pointer; flex-shrink: 0; }
 .switch input { display: none; }
 .switch .track {
-  position: absolute; inset: 0; border-radius: 12px;
+  position: absolute; inset: 0; border-radius: 11px;
   background: #cc8888; transition: background 0.25s;
 }
 .switch input:checked + .track { background: #88cc88; }
 .switch .thumb {
-  position: absolute; top: 2px; left: 2px; width: 20px; height: 20px;
+  position: absolute; top: 2px; left: 2px; width: 18px; height: 18px;
   border-radius: 50%; background: #fff; transition: transform 0.25s;
   pointer-events: none;
 }
-.switch input:checked ~ .thumb { transform: translateX(20px); }
+.switch input:checked ~ .thumb { transform: translateX(18px); }
+
+.sep { width: 1px; height: 20px; background: #282828; flex-shrink: 0; }
+
+.slider-group { display: flex; align-items: center; gap: 6px; }
+.slider-group label { font-size: 11px; color: #555; text-transform: uppercase; letter-spacing: 0.4px; }
+.slider-group input[type=range] {
+  -webkit-appearance: none; appearance: none;
+  width: 100px; height: 4px; background: #333; border-radius: 2px; outline: none;
+}
+.slider-group input[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none; appearance: none;
+  width: 14px; height: 14px; border-radius: 50%; background: #aaa; cursor: pointer;
+  border: none;
+}
+.slider-group input[type=range]::-moz-range-thumb {
+  width: 14px; height: 14px; border-radius: 50%; background: #aaa; cursor: pointer;
+  border: none;
+}
+.slider-group .val {
+  font-size: 11px; color: #888; min-width: 34px; font-variant-numeric: tabular-nums;
+  text-align: right;
+}
 
 .timing {
-  font-size: 13px; font-weight: 600; font-variant-numeric: tabular-nums;
-  text-align: center;
-  transition: color 0.2s;
+  font-size: 12px; font-weight: 600; font-variant-numeric: tabular-nums;
+  text-align: center; transition: color 0.2s;
 }
 .timing.dom { color: #cc8888; }
 .timing.pretext { color: #88cc88; }
 
-.chat { flex: 1; overflow-y: auto; position: relative; margin: 0 auto; max-width: 100%; }
+/* --- Chat --- */
+
+.chat { flex: 1; overflow-y: auto; position: relative; margin: 0 auto; max-width: 100%; scrollbar-width: none; }
+.chat::-webkit-scrollbar { display: none; }
 .chat-content { position: relative; }
 
 .msg { position: absolute; left: 0; right: 0; padding: 3px 16px; display: flex; overflow: hidden; }
@@ -61,7 +86,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
 </style>
 </head>
 <body>
-<div class="top-bar">
+<div class="controls">
   <div class="toggle">
     <span class="toggle-label dom active">DOM</span>
     <label class="switch">
@@ -71,16 +96,18 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
     </label>
     <span class="toggle-label pretext">Pretext</span>
   </div>
-  <div class="control">
+  <div class="sep"></div>
+  <div class="slider-group">
     <label>Width</label>
     <input type="range" id="width-slider" min="250" max="900" value="600" step="1" />
     <span class="val" id="width-val">600px</span>
   </div>
-  <div class="control">
+  <div class="slider-group">
     <label>Font</label>
     <input type="range" id="font-slider" min="11" max="28" value="15" step="1" />
     <span class="val" id="font-val">15px</span>
   </div>
+  <div class="sep"></div>
   <span class="timing dom" id="timing">—</span>
 </div>
 <div class="chat" id="chat">

--- a/pages/demos/virtual-chat.html
+++ b/pages/demos/virtual-chat.html
@@ -6,11 +6,11 @@
 <title>Virtual Chat — DOM vs Pretext</title>
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
-body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0f0f0f; color: #e0e0e0; height: 100vh; overflow: hidden; }
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0f0f0f; color: #e0e0e0; height: 100vh; overflow: hidden; display: flex; flex-direction: column; }
 
 .top-bar {
-  height: 52px; display: flex; align-items: center; justify-content: center; gap: 28px;
-  background: #1a1a1a; border-bottom: 1px solid #333; padding: 0 24px; flex-shrink: 0;
+  display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 12px 24px;
+  background: #1a1a1a; border-bottom: 1px solid #333; padding: 10px 16px; flex-shrink: 0;
 }
 .control { display: flex; align-items: center; gap: 8px; }
 .control label { font-size: 12px; color: #888; }
@@ -23,7 +23,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
 .toggle-label.active { font-weight: 600; }
 .toggle-label.dom.active { color: #cc8888; }
 .toggle-label.pretext.active { color: #88cc88; }
-.switch { position: relative; width: 44px; height: 24px; cursor: pointer; }
+.switch { position: relative; width: 44px; height: 24px; cursor: pointer; flex-shrink: 0; }
 .switch input { display: none; }
 .switch .track {
   position: absolute; inset: 0; border-radius: 12px;
@@ -39,13 +39,13 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
 
 .timing {
   font-size: 13px; font-weight: 600; font-variant-numeric: tabular-nums;
-  min-width: 180px; text-align: right;
+  text-align: center;
   transition: color 0.2s;
 }
 .timing.dom { color: #cc8888; }
 .timing.pretext { color: #88cc88; }
 
-.chat { height: calc(100vh - 52px); overflow-y: auto; position: relative; margin: 0 auto; }
+.chat { flex: 1; overflow-y: auto; position: relative; margin: 0 auto; max-width: 100%; }
 .chat-content { position: relative; }
 
 .msg { position: absolute; left: 0; right: 0; padding: 3px 16px; display: flex; overflow: hidden; }

--- a/pages/demos/virtual-chat.html
+++ b/pages/demos/virtual-chat.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Virtual Chat — DOM vs Pretext</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0f0f0f; color: #e0e0e0; height: 100vh; overflow: hidden; }
+
+.top-bar {
+  height: 52px; display: flex; align-items: center; justify-content: center; gap: 28px;
+  background: #1a1a1a; border-bottom: 1px solid #333; padding: 0 24px; flex-shrink: 0;
+}
+.control { display: flex; align-items: center; gap: 8px; }
+.control label { font-size: 12px; color: #888; }
+.control input[type=range] { width: 110px; accent-color: #666; }
+.control .val { font-size: 12px; color: #ccc; min-width: 36px; font-variant-numeric: tabular-nums; }
+
+/* Toggle switch */
+.toggle { display: flex; align-items: center; gap: 10px; }
+.toggle-label { font-size: 12px; color: #888; text-transform: uppercase; letter-spacing: 0.5px; transition: color 0.2s; }
+.toggle-label.active { font-weight: 600; }
+.toggle-label.dom.active { color: #cc8888; }
+.toggle-label.pretext.active { color: #88cc88; }
+.switch { position: relative; width: 44px; height: 24px; cursor: pointer; }
+.switch input { display: none; }
+.switch .track {
+  position: absolute; inset: 0; border-radius: 12px;
+  background: #cc8888; transition: background 0.25s;
+}
+.switch input:checked + .track { background: #88cc88; }
+.switch .thumb {
+  position: absolute; top: 2px; left: 2px; width: 20px; height: 20px;
+  border-radius: 50%; background: #fff; transition: transform 0.25s;
+  pointer-events: none;
+}
+.switch input:checked ~ .thumb { transform: translateX(20px); }
+
+.timing {
+  font-size: 13px; font-weight: 600; font-variant-numeric: tabular-nums;
+  min-width: 180px; text-align: right;
+  transition: color 0.2s;
+}
+.timing.dom { color: #cc8888; }
+.timing.pretext { color: #88cc88; }
+
+.chat { height: calc(100vh - 52px); overflow-y: auto; position: relative; margin: 0 auto; }
+.chat-content { position: relative; }
+
+.msg { position: absolute; left: 0; right: 0; padding: 3px 16px; display: flex; overflow: hidden; }
+.msg.sent { justify-content: flex-end; }
+.msg.received { justify-content: flex-start; }
+
+.bubble {
+  padding: 8px 12px; border-radius: 16px; overflow: hidden;
+  word-break: normal; overflow-wrap: break-word; white-space: normal;
+}
+.msg.sent .bubble { border-bottom-right-radius: 4px; }
+.msg.received .bubble { border-bottom-left-radius: 4px; }
+</style>
+</head>
+<body>
+<div class="top-bar">
+  <div class="toggle">
+    <span class="toggle-label dom active">DOM</span>
+    <label class="switch">
+      <input type="checkbox" id="mode-toggle" />
+      <div class="track"></div>
+      <div class="thumb"></div>
+    </label>
+    <span class="toggle-label pretext">Pretext</span>
+  </div>
+  <div class="control">
+    <label>Width</label>
+    <input type="range" id="width-slider" min="250" max="900" value="600" step="1" />
+    <span class="val" id="width-val">600px</span>
+  </div>
+  <div class="control">
+    <label>Font</label>
+    <input type="range" id="font-slider" min="11" max="28" value="15" step="1" />
+    <span class="val" id="font-val">15px</span>
+  </div>
+  <span class="timing dom" id="timing">—</span>
+</div>
+<div class="chat" id="chat">
+  <div class="chat-content" id="chat-content"></div>
+</div>
+<script type="module" src="./virtual-chat.ts"></script>
+</body>
+</html>

--- a/pages/demos/virtual-chat.ts
+++ b/pages/demos/virtual-chat.ts
@@ -348,7 +348,7 @@ function boot(): void {
     } else {
       const result = measureWithDOM(messages, st.chatWidth, st.baseFontSize, heights, offsets)
       st.totalH = result.totalH
-      detail = `${result.ms.toFixed(1)}ms`
+      detail = `${result.ms.toFixed(1)}ms measure`
     }
 
     rendered.forEach(el => el.remove())

--- a/pages/demos/virtual-chat.ts
+++ b/pages/demos/virtual-chat.ts
@@ -1,0 +1,402 @@
+import { prepare, layout, type PreparedText } from '../../src/layout.ts'
+
+// --- Data ---
+
+const SNIPPETS: readonly string[] = [
+  'hey', 'hi!', 'what\'s up', 'nm u?', 'lol', 'ok', 'sure', 'sounds good', 'haha', '👍',
+  'omg that\'s hilarious 😂', 'wait what happened??', 'no way', 'seriously?', 'I can\'t believe it',
+  'yeah I was thinking the same thing honestly', 'did you see that tweet about the new AI model?',
+  'I just finished reading that book you recommended, it was actually really good',
+  'btw do you know if the meeting tomorrow is at 10 or 11? I keep getting conflicting info from different people',
+  'I\'ve been trying to fix this bug for three hours and I think I finally found it. Turns out it was a race condition in the event handler that only triggers when you resize the window while scrolling. Classic.',
+  'The restaurant on 5th street has amazing ramen. We should go sometime this week if you\'re free. They close early on weekdays though so we\'d need to get there before 8.',
+  'https://github.com/some/really-long-url/that-wraps?query=param&foo=bar',
+  'Remember when we tried to deploy on Friday and everything broke? Good times 🙃',
+  'Can you review my PR when you get a chance? It\'s the one that refactors the auth middleware. Not urgent but would be nice to get it merged before the sprint ends.',
+  'I think the API is returning stale data. The cache TTL might be too aggressive. Let me check the config... yeah it\'s set to 24h which seems way too long for user preferences.',
+  '春天到了，天气越来越暖和了！你那边怎么样？',
+  'مرحبا! كيف حالك اليوم؟ أتمنى أن يكون يومك جميلا',
+  'こんにちは！最近どうですか？新しいプロジェクトはうまくいっていますか？',
+  'The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog.',
+  '🎉🎊🥳 Happy birthday!!! 🎂🎈🎁',
+  'TL;DR: the whole backend needs to be rewritten because someone thought it was a good idea to store JSON in a TEXT column and parse it on every single request. Performance is abysmal. We need to migrate to a proper schema with indexed columns.',
+]
+
+const SENT_COLORS: readonly string[] = ['#1a4a8a', '#2a4a6a', '#1a3a6a', '#2a3a8a', '#1a4a7a']
+const RECV_COLORS: readonly string[] = ['#2a2a2a', '#2a2a35', '#302a2a', '#2a302a', '#2d2a2a']
+
+// --- Types ---
+
+type Message = {
+  text: string
+  sent: boolean
+  color: string
+  sizeOffset: number
+}
+
+type DomCache = {
+  scrollEl: HTMLElement
+  contentEl: HTMLElement
+  timingEl: HTMLElement
+  modeToggle: HTMLInputElement
+  domLabel: Element
+  pretextLabel: Element
+  widthSlider: HTMLInputElement
+  widthValEl: HTMLElement
+  fontSlider: HTMLInputElement
+  fontValEl: HTMLElement
+}
+
+// --- Constants ---
+
+const MSG_COUNT = 5000
+const BUBBLE_PAD_V = 16 // 8 + 8 px vertical padding on .bubble
+const BUBBLE_PAD_H = 24 // 12 + 12 px horizontal padding on .bubble
+const MSG_PAD_V = 6     // 3 + 3 px vertical padding on .msg
+const MSG_PAD_H = 32    // 16 + 16 px horizontal padding on .msg
+const OVERSCAN = 5
+const FONT_FAMILY = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
+const FPS_WINDOW_MS = 400
+const FPS_DISPLAY_MS = 1000
+
+// --- Helpers ---
+
+function fontStr(size: number): string {
+  return `${size}px ${FONT_FAMILY}`
+}
+
+function lineH(size: number): number {
+  return Math.round(size * 1.47)
+}
+
+function maxBubbleContentW(chatWidth: number): number {
+  return Math.floor((chatWidth - MSG_PAD_H) * 0.75) - BUBBLE_PAD_H
+}
+
+function seededRandom(seed: number): () => number {
+  return () => { seed = (seed * 16807) % 2147483647; return (seed - 1) / 2147483646 }
+}
+
+function pick<T>(arr: readonly T[], rand: () => number): T {
+  return arr[Math.floor(rand() * arr.length)]!
+}
+
+function getRequiredElement(id: string): HTMLElement {
+  const el = document.getElementById(id)
+  if (!(el instanceof HTMLElement)) throw new Error(`#${id} not found`)
+  return el
+}
+
+function getRequiredInput(id: string): HTMLInputElement {
+  const el = document.getElementById(id)
+  if (!(el instanceof HTMLInputElement)) throw new Error(`#${id} not found`)
+  return el
+}
+
+function getRequiredBySelector(selector: string): Element {
+  const el = document.querySelector(selector)
+  if (el === null) throw new Error(`${selector} not found`)
+  return el
+}
+
+// --- Message generation ---
+
+function generateMessages(): Message[] {
+  const rand = seededRandom(42)
+  const msgs: Message[] = []
+  for (let i = 0; i < MSG_COUNT; i++) {
+    const partCount = Math.floor(rand() * 3) + 1
+    let text = ''
+    for (let p = 0; p < partCount; p++) {
+      if (p > 0) text += ' '
+      text += pick(SNIPPETS, rand)
+    }
+    const sent = rand() > 0.45
+    msgs.push({
+      text,
+      sent,
+      color: sent ? pick(SENT_COLORS, rand) : pick(RECV_COLORS, rand),
+      sizeOffset: Math.floor(rand() * 6) - 2,
+    })
+  }
+  return msgs
+}
+
+// --- Virtualizer ---
+
+function renderVisible(
+  dom: DomCache,
+  messages: Message[],
+  heights: Float64Array,
+  offsets: Float64Array,
+  totalH: number,
+  baseFontSize: number,
+  rendered: Map<number, HTMLElement>,
+): void {
+  dom.contentEl.style.height = totalH + 'px'
+  const scrollTop = dom.scrollEl.scrollTop
+  const viewH = dom.scrollEl.clientHeight
+
+  // Binary search for first visible message
+  let lo = 0
+  let hi = MSG_COUNT - 1
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1
+    if (offsets[mid]! + heights[mid]! < scrollTop) lo = mid + 1
+    else hi = mid
+  }
+  const first = Math.max(0, lo - OVERSCAN)
+  let last = first
+  while (last < MSG_COUNT - 1 && offsets[last]! < scrollTop + viewH) last++
+  last = Math.min(MSG_COUNT - 1, last + OVERSCAN)
+
+  // Evict off-screen elements
+  const visible = new Set<number>()
+  for (let i = first; i <= last; i++) visible.add(i)
+  rendered.forEach((el, idx) => {
+    if (!visible.has(idx)) { el.remove(); rendered.delete(idx) }
+  })
+
+  // Create newly visible elements
+  const bubbleOuterW = maxBubbleContentW(dom.scrollEl.clientWidth) + BUBBLE_PAD_H
+  for (let i = first; i <= last; i++) {
+    if (rendered.has(i)) continue
+    const m = messages[i]!
+    const sz = baseFontSize + m.sizeOffset
+    const el = document.createElement('div')
+    el.className = `msg ${m.sent ? 'sent' : 'received'}`
+    el.style.top = offsets[i]! + 'px'
+    el.style.height = heights[i]! + 'px'
+    const bubble = document.createElement('div')
+    bubble.className = 'bubble'
+    bubble.style.cssText =
+      `max-width:${bubbleOuterW}px;` +
+      `background:${m.color};` +
+      `font:${fontStr(sz)};` +
+      `line-height:${lineH(sz)}px;` +
+      `color:${m.sent ? '#e8f0fe' : '#e0e0e0'};`
+    bubble.textContent = m.text
+    el.appendChild(bubble)
+    dom.contentEl.appendChild(el)
+    rendered.set(i, el)
+  }
+}
+
+// --- Measurement: Pretext ---
+
+function measureWithPretext(
+  messages: Message[],
+  prepared: PreparedText[],
+  chatWidth: number,
+  baseFontSize: number,
+  heights: Float64Array,
+  offsets: Float64Array,
+): { totalH: number; ms: number } {
+  const maxW = maxBubbleContentW(chatWidth)
+  const t0 = performance.now()
+  let offset = 0
+  for (let i = 0; i < MSG_COUNT; i++) {
+    const sz = baseFontSize + messages[i]!.sizeOffset
+    const h = layout(prepared[i]!, maxW, lineH(sz)).height + BUBBLE_PAD_V + MSG_PAD_V
+    heights[i] = h
+    offsets[i] = offset
+    offset += h
+  }
+  return { totalH: offset, ms: performance.now() - t0 }
+}
+
+// --- Measurement: DOM ---
+
+function measureWithDOM(
+  messages: Message[],
+  chatWidth: number,
+  baseFontSize: number,
+  heights: Float64Array,
+  offsets: Float64Array,
+): { totalH: number; ms: number } {
+  const maxW = maxBubbleContentW(chatWidth)
+  const t0 = performance.now()
+
+  const container = document.createElement('div')
+  container.style.cssText = `position:absolute;visibility:hidden;top:0;left:0;width:${chatWidth}px;`
+  const els: HTMLElement[] = new Array(MSG_COUNT)
+
+  for (let i = 0; i < MSG_COUNT; i++) {
+    const m = messages[i]!
+    const sz = baseFontSize + m.sizeOffset
+    const el = document.createElement('div')
+    el.style.cssText =
+      `max-width:${maxW + BUBBLE_PAD_H}px;width:fit-content;` +
+      `font:${fontStr(sz)};line-height:${lineH(sz)}px;` +
+      `word-break:normal;overflow-wrap:break-word;white-space:normal;` +
+      `padding:8px 12px;box-sizing:border-box;`
+    el.textContent = m.text
+    container.appendChild(el)
+    els[i] = el
+  }
+  document.body.appendChild(container)
+
+  let offset = 0
+  for (let i = 0; i < MSG_COUNT; i++) {
+    const h = els[i]!.offsetHeight + MSG_PAD_V
+    heights[i] = h
+    offsets[i] = offset
+    offset += h
+  }
+  document.body.removeChild(container)
+
+  return { totalH: offset, ms: performance.now() - t0 }
+}
+
+// --- FPS counter ---
+
+function createFpsCounter() {
+  let frames = 0
+  let windowStart = performance.now()
+  let display = ''
+  return {
+    tick(): void {
+      frames++
+      const now = performance.now()
+      if (now - windowStart >= FPS_WINDOW_MS) {
+        display = `${Math.round(frames / ((now - windowStart) / 1000))} fps`
+        frames = 0
+        windowStart = now
+      }
+    },
+    get text(): string { return display },
+  }
+}
+
+// --- Boot ---
+
+const messages = generateMessages()
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', boot, { once: true })
+} else {
+  boot()
+}
+
+function boot(): void {
+  const dom: DomCache = {
+    scrollEl: getRequiredElement('chat'),
+    contentEl: getRequiredElement('chat-content'),
+    timingEl: getRequiredElement('timing'),
+    modeToggle: getRequiredInput('mode-toggle'),
+    domLabel: getRequiredBySelector('.toggle-label.dom'),
+    pretextLabel: getRequiredBySelector('.toggle-label.pretext'),
+    widthSlider: getRequiredInput('width-slider'),
+    widthValEl: getRequiredElement('width-val'),
+    fontSlider: getRequiredInput('font-slider'),
+    fontValEl: getRequiredElement('font-val'),
+  }
+
+  const st = {
+    baseFontSize: 15,
+    chatWidth: 600,
+    usePretext: false,
+    totalH: 0,
+    preparedFontSize: -1,
+  }
+
+  const heights = new Float64Array(MSG_COUNT)
+  const offsets = new Float64Array(MSG_COUNT)
+  let prepared: PreparedText[] = []
+  const rendered = new Map<number, HTMLElement>()
+  const fps = createFpsCounter()
+  let fpsResetTimer = 0
+  let scheduledRaf: number | null = null
+
+  dom.scrollEl.style.width = st.chatWidth + 'px'
+
+  // --- Prepare ---
+
+  function ensurePrepared(): number {
+    if (st.preparedFontSize === st.baseFontSize) return 0
+    const t0 = performance.now()
+    prepared = new Array(MSG_COUNT)
+    for (let i = 0; i < MSG_COUNT; i++) {
+      const m = messages[i]!
+      prepared[i] = prepare(m.text, fontStr(st.baseFontSize + m.sizeOffset))
+    }
+    st.preparedFontSize = st.baseFontSize
+    return performance.now() - t0
+  }
+
+  // --- Update cycle ---
+
+  function fullUpdate(fontChanged: boolean): void {
+    let detail: string
+
+    if (st.usePretext) {
+      const prepMs = fontChanged ? ensurePrepared() : 0
+      const result = measureWithPretext(messages, prepared, st.chatWidth, st.baseFontSize, heights, offsets)
+      st.totalH = result.totalH
+      detail = fontChanged && prepMs > 0
+        ? `${prepMs.toFixed(1)}ms prepare + ${result.ms.toFixed(1)}ms layout`
+        : `${result.ms.toFixed(1)}ms layout`
+    } else {
+      const result = measureWithDOM(messages, st.chatWidth, st.baseFontSize, heights, offsets)
+      st.totalH = result.totalH
+      detail = `${result.ms.toFixed(1)}ms`
+    }
+
+    rendered.forEach(el => el.remove())
+    rendered.clear()
+    renderVisible(dom, messages, heights, offsets, st.totalH, st.baseFontSize, rendered)
+
+    fps.tick()
+    dom.timingEl.textContent = fps.text ? `${detail}  ·  ${fps.text}` : detail
+    clearTimeout(fpsResetTimer)
+    fpsResetTimer = window.setTimeout(() => { dom.timingEl.textContent = detail }, FPS_DISPLAY_MS)
+  }
+
+  function scheduleRender(): void {
+    if (scheduledRaf !== null) return
+    scheduledRaf = requestAnimationFrame(() => {
+      scheduledRaf = null
+      if (st.totalH === 0) return
+      renderVisible(dom, messages, heights, offsets, st.totalH, st.baseFontSize, rendered)
+    })
+  }
+
+  // --- Toggle ---
+
+  function syncToggleUI(): void {
+    dom.domLabel.classList.toggle('active', !st.usePretext)
+    dom.pretextLabel.classList.toggle('active', st.usePretext)
+    dom.timingEl.classList.toggle('dom', !st.usePretext)
+    dom.timingEl.classList.toggle('pretext', st.usePretext)
+  }
+
+  dom.modeToggle.addEventListener('change', () => {
+    st.usePretext = dom.modeToggle.checked
+    syncToggleUI()
+    const scrollPct = dom.scrollEl.scrollTop / (st.totalH - dom.scrollEl.clientHeight || 1)
+    fullUpdate(true)
+    dom.scrollEl.scrollTop = scrollPct * (st.totalH - dom.scrollEl.clientHeight || 1)
+  })
+
+  // --- Sliders ---
+
+  dom.widthSlider.addEventListener('input', () => {
+    st.chatWidth = Number.parseInt(dom.widthSlider.value, 10)
+    dom.widthValEl.textContent = st.chatWidth + 'px'
+    dom.scrollEl.style.width = st.chatWidth + 'px'
+    fullUpdate(false)
+  })
+
+  dom.fontSlider.addEventListener('input', () => {
+    st.baseFontSize = Number.parseInt(dom.fontSlider.value, 10)
+    dom.fontValEl.textContent = st.baseFontSize + 'px'
+    fullUpdate(true)
+  })
+
+  dom.scrollEl.addEventListener('scroll', scheduleRender)
+
+  // --- Init ---
+
+  syncToggleUI()
+  document.fonts.ready.then(() => fullUpdate(true))
+}

--- a/pages/demos/virtual-chat.ts
+++ b/pages/demos/virtual-chat.ts
@@ -292,9 +292,18 @@ function boot(): void {
     fontValEl: getRequiredElement('font-val'),
   }
 
+  const viewportW = document.documentElement.clientWidth
+  const initialWidth = Math.min(600, viewportW - 32)
+
+  // Clamp slider range to viewport
+  const sliderMax = Math.min(900, viewportW - 32)
+  dom.widthSlider.max = String(sliderMax)
+  dom.widthSlider.value = String(initialWidth)
+  dom.widthValEl.textContent = initialWidth + 'px'
+
   const st = {
     baseFontSize: 15,
-    chatWidth: 600,
+    chatWidth: initialWidth,
     usePretext: false,
     totalH: 0,
     preparedFontSize: -1,

--- a/scripts/build-demo-site.ts
+++ b/scripts/build-demo-site.ts
@@ -13,6 +13,7 @@ const entrypoints = [
   'pages/demos/masonry/index.html',
   'pages/demos/rich-note.html',
   'pages/demos/variable-typographic-ascii.html',
+  'pages/demos/virtual-chat.html',
 ]
 
 const result = Bun.spawnSync(
@@ -38,6 +39,7 @@ const targets = [
   { source: 'masonry/index.html', target: 'masonry/index.html' },
   { source: 'rich-note.html', target: 'rich-note/index.html' },
   { source: 'variable-typographic-ascii.html', target: 'variable-typographic-ascii/index.html' },
+  { source: 'virtual-chat.html', target: 'virtual-chat/index.html' },
 ]
 
 for (let index = 0; index < targets.length; index++) {


### PR DESCRIPTION
## Summary

Adds a virtualized chat demo with a toggle between DOM `offsetHeight` measurement with batching and Pretext `layout()` which directly compares DOM measurement cost against Pretext in a familiar and relatable way

  ## Test plan

  - [x] `bun run check` passes
  - [x] `bun start`, open `/demos/virtual-chat` — toggle, scroll, drag both sliders
  - [x] Verify the demo card appears on `/demos/index`
  - [x] Verify `bun run site:build` includes the new page

![virtual-chat-demo](https://github.com/user-attachments/assets/7201d5c8-f7e9-4add-83fc-869934be544f)
