### PR TITLE
fix: unify countPreparedLines with walkPreparedLines to fix lineCount mismatch (#49)

### DIFF
--- a/src/line-break.ts
+++ b/src/line-break.ts
@@ -131,9 +131,11 @@ export function normalizeLineStart(
 }
 
 export function countPreparedLines(prepared: PreparedLineBreakData, maxWidth: number): number {
-  if (prepared.simpleLineWalkFastPath) {
-    return countPreparedLinesSimple(prepared, maxWidth)
-  }
+  // Unify with walkPreparedLines to guarantee layout() and layoutWithLines()
+  // always agree on lineCount. The previous dedicated countPreparedLinesSimple
+  // fast path diverged from walkPreparedLinesSimple in the overflow-wrap
+  // grapheme-breaking and canBreakAfter codepaths, causing off-by-one
+  // lineCount mismatches. See #49.
   return walkPreparedLines(prepared, maxWidth)
 }
 


### PR DESCRIPTION
## Summary

Fixes #49.

`layout()` and `layoutWithLines()` returned different `lineCount` values when text contained ZWSP (`U+200B`) break opportunities at narrow widths that triggered overflow-wrap grapheme-level breaking.

## Root Cause

`countPreparedLinesSimple` (used by `layout()` via `countPreparedLines`) had two divergences from `walkPreparedLinesSimple` (used by `layoutWithLines()`):

1. **Grapheme-breaking counting**: The count path incremented `lineCount` at the **start** of each grapheme line (`if (lineW === 0) lineCount++`), while the walk path only emits lines at **overflow points** or at the end. This caused an off-by-one when a breakable segment's graphemes all fit within `maxWidth`.

2. **Missing `canBreakAfter` branch**: The count path's overflow handler unconditionally reset `hasContent` and called `placeOnFreshLine`, while the walk path first checked `canBreakAfter(kind)` to append the current segment to the line before emitting. This caused segments like ZWSP to be placed on their own line in the count path but merged into the previous line in the walk path.

## Fix

Remove the separate `countPreparedLinesSimple` fast path and always delegate `countPreparedLines` to `walkPreparedLines` (without an `onLine` callback). This guarantees `layout()` and `layoutWithLines()` always produce identical `lineCount`.

## Before / After

```ts
const text = 'alpha\u200Bbeta'  // ZWSP between words
const prepared = prepare(text, '16px Inter')

// Before fix (at maxWidth = 10):
layout(prepared, 10, 19).lineCount           // 10
layoutWithLines(prepared, 10, 19).lineCount  // 9  <-- disagrees!

// After fix:
layout(prepared, 10, 19).lineCount           // 9
layoutWithLines(prepared, 10, 19).lineCount  // 9  <-- agrees!
```

## Testing

- All 60 existing tests pass (`bun test src/layout.test.ts`)
- Verified with systematic fuzz testing (361 tests across 23 text variants x multiple widths): `layout()`, `layoutWithLines()`, `walkLineRanges()`, and `layoutNextLine()` now agree on lineCount for all tested inputs (except for a separate `layoutNextLine` issue tracked in #50)

## Performance Note

This change removes the count-only fast path, which means `layout()` now runs the full walk logic internally (without materializing line objects since no `onLine` callback is passed). The walk path already skips string construction and line-object allocation when `onLine` is undefined, so the practical overhead should be minimal. If performance regression is a concern, the count path could be restored by carefully porting the walk path's `canBreakAfter` branch and deferred grapheme counting — but given the subtlety of the divergence, I believe correctness should take priority.
