### PR TITLE
chore: add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@chenglou/pretext",
   "version": "0.0.3",
   "license": "MIT",
+  "repository": "github:chenglou/pretext",
   "type": "module",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Adds the `repository` field to `package.json`

(this makes the repo discoverable from https://www.npmjs.com/package/@chenglou/pretext)

--
using the shorthand repository field syntax outlined here: https://docs.npmjs.com/cli/v10/configuring-npm/package-json