### PR TITLE
Fix undefined variable in README example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pretext serves 2 use cases:
 import { prepare, layout } from '@chenglou/pretext'
 
 const prepared = prepare('AGI 春天到了. بدأت الرحلة 🚀', '16px Inter')
-const { height, lineCount } = layout(prepared, textWidth, 20) // pure arithmetics. No DOM layout & reflow!
+const { height, lineCount } = layout(prepared, 320, 20) // pure arithmetics. No DOM layout & reflow!
 ```
 
 `prepare()` does the one-time work: normalize whitespace, segment the text, apply glue rules, measure the segments with canvas, and return an opaque handle. `layout()` is the cheap hot path after that: pure arithmetic over cached widths. Do not rerun `prepare()` for the same text and configs; that'd defeat its precomputation. For example, on resize, only rerun `layout()`.


### PR DESCRIPTION
## Problem

The example code in the "Measure a paragraph's height" section (line 28) used an undefined variable `textWidth`:

```typescript
const { height, lineCount } = layout(prepared, textWidth, 20)
```

This would cause a `ReferenceError: textWidth is not defined` if someone tries to run this code directly.

## Solution

Changed the undefined variable to a concrete value (320) to match the other examples in the documentation that use `320px` as the max width:

```typescript
const { height, lineCount } = layout(prepared, 320, 20)
```

This makes the example code immediately runnable without modification.

## Testing

The fix is purely documentation-only. No code changes were made.