### PR TITLE
Add LTR mark to README example string for bidi readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Pretext serves 2 use cases:
 ```ts
 import { prepare, layout } from '@chenglou/pretext'
 
-const prepared = prepare('AGI 春天到了. بدأت الرحلة 🚀', '16px Inter')
+const prepared = prepare('AGI 春天到了. بدأت الرحلة 🚀‎', '16px Inter')
 const { height, lineCount } = layout(prepared, textWidth, 20) // pure arithmetics. No DOM layout & reflow!
 ```
 


### PR DESCRIPTION
So confusing at first glance.
 
before:
<img width="596" height="32" alt="Screenshot 2026-03-31 at 23 47 15" src="https://github.com/user-attachments/assets/ca6b2243-18f6-4f2e-8574-fa1f7bd16318" />

after:
<img width="584" height="23" alt="Screenshot 2026-03-31 at 23 47 38" src="https://github.com/user-attachments/assets/86bd3d07-db1b-4028-8491-1d64f0a3a2da" />
