### PR TITLE
Cleanup files to be published to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,7 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "CHANGELOG.md",
-    "dist",
-    "src",
-    "!src/layout.test.ts",
-    "!src/test-data.ts",
-    "pages/demos",
-    "pages/assets",
-    "LICENSE"
+    "dist"
   ],
   "scripts": {
     "accuracy-check": "bun run scripts/accuracy-check.ts",


### PR DESCRIPTION
It looks like some files are published to npm by accident.

What was the reasoning behind uploading those files to npm previously?

In the meantime, here is why I remove them:

- CHANGELOG.md - Useless for package distribution
- src/ - Useless for package distribution
- pages/ - Useless for package distribution
- LICENSE - npm included this file by default, you don't need to list the file here

