### PR TITLE
docs: link to community awesome-pretext list

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ npm install @chenglou/pretext
 Clone the repo, run `bun install`, then `bun start`, and open the `/demos` in your browser (no trailing slash. Bun devserver bugs on those)
 Alternatively, see them live at [chenglou.me/pretext](https://chenglou.me/pretext/). Some more at [somnai-dreams.github.io/pretext-demos](https://somnai-dreams.github.io/pretext-demos/)
 
+Community packages and experiments: [awesome-pretext](https://github.com/ShipItAndPray/awesome-pretext)
+
 ## API
 
 Pretext serves 2 use cases:


### PR DESCRIPTION
Adds a one-liner pointing to the community-maintained [awesome-pretext](https://github.com/ShipItAndPray/awesome-pretext) list — 42 packages with live demos, plus a few third-party experiments.

Placed right after the existing somnai-dreams link in the Demos section so it reads naturally.