### PR TITLE
fix: currency symbols stick to adjacent numbers during line breaking

### DIFF
--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -97,6 +97,7 @@ export function setAnalysisLocale(locale?: string): void {
 
 const arabicScriptRe = /\p{Script=Arabic}/u
 const combiningMarkRe = /\p{M}/u
+const currencySymbolRe = /\p{Sc}/u
 const decimalDigitRe = /\p{Nd}/u
 
 function containsArabicScript(text: string): boolean {
@@ -270,7 +271,7 @@ function isLeftStickyPunctuationSegment(segment: string): boolean {
   if (isEscapedQuoteClusterSegment(segment)) return true
   let sawPunctuation = false
   for (const ch of segment) {
-    if (leftStickyPunctuation.has(ch)) {
+    if (leftStickyPunctuation.has(ch) || currencySymbolRe.test(ch)) {
       sawPunctuation = true
       continue
     }
@@ -290,7 +291,7 @@ function isCJKLineStartProhibitedSegment(segment: string): boolean {
 function isForwardStickyClusterSegment(segment: string): boolean {
   if (isEscapedQuoteClusterSegment(segment)) return true
   for (const ch of segment) {
-    if (!kinsokuEnd.has(ch) && !forwardStickyGlue.has(ch) && !combiningMarkRe.test(ch)) return false
+    if (!kinsokuEnd.has(ch) && !forwardStickyGlue.has(ch) && !combiningMarkRe.test(ch) && !currencySymbolRe.test(ch)) return false
   }
   return segment.length > 0
 }

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -465,6 +465,16 @@ describe('prepare invariants', () => {
     expect(prepared.segments).toEqual(['say', ' ', String.raw`\"hello\"`, ' ', 'there'])
   })
 
+  test('keeps prefix currency symbols attached to the following number', () => {
+    const prepared = prepareWithSegments('costs $500 today', FONT)
+    expect(prepared.segments).toEqual(['costs', ' ', '$500', ' ', 'today'])
+  })
+
+  test('keeps postfix currency symbols attached to the preceding number', () => {
+    const prepared = prepareWithSegments('price 500€ each', FONT)
+    expect(prepared.segments).toEqual(['price', ' ', '500€', ' ', 'each'])
+  })
+
   test('keeps URL-like runs together as one breakable segment', () => {
     const prepared = prepareWithSegments('see https://example.com/reports/q3?lang=ar&mode=full now', FONT)
     expect(prepared.segments).toEqual([


### PR DESCRIPTION
Fixes #98

Currency symbols (`$`, `£`, `€`, `¥`, etc.) were getting segmented separately from adjacent text by `Intl.Segmenter`, leaving a breakable gap. So pretext could wrap between `$` and `500`, or between `500` and `€`, which browsers don't do.

Added a `\p{Sc}` (Unicode currency symbol category) check to both the forward-sticky and left-sticky merge passes in `analysis.ts`. This covers prefix (`$500`) and postfix (`500€`) currencies, matching browser behavior.

Before:
- `$500` -> segments `["$", "500"]` (breakable)
- `500€` -> segments `["500", "€"]` (breakable)

After:
- `$500` -> segments `["$500"]`
- `500€` -> segments `["500€"]`

Tested in Chromium on Windows across `$`, `£`, `€`, `¥`, `₹` at various widths. All match browser line counts. 81/81 existing tests pass.