### PR TITLE
Add optional Playwright Chrome correctness driver

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "marked": "^17.0.5",
         "oxlint": "^1.51.0",
         "oxlint-tsgolint": "^0.15.0",
+        "playwright-core": "^1.59.1",
         "tsgolint": "^0.0.1",
         "typescript": "6.0.2",
       },
@@ -76,6 +77,8 @@
     "oxlint": ["oxlint@1.51.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.51.0", "@oxlint/binding-android-arm64": "1.51.0", "@oxlint/binding-darwin-arm64": "1.51.0", "@oxlint/binding-darwin-x64": "1.51.0", "@oxlint/binding-freebsd-x64": "1.51.0", "@oxlint/binding-linux-arm-gnueabihf": "1.51.0", "@oxlint/binding-linux-arm-musleabihf": "1.51.0", "@oxlint/binding-linux-arm64-gnu": "1.51.0", "@oxlint/binding-linux-arm64-musl": "1.51.0", "@oxlint/binding-linux-ppc64-gnu": "1.51.0", "@oxlint/binding-linux-riscv64-gnu": "1.51.0", "@oxlint/binding-linux-riscv64-musl": "1.51.0", "@oxlint/binding-linux-s390x-gnu": "1.51.0", "@oxlint/binding-linux-x64-gnu": "1.51.0", "@oxlint/binding-linux-x64-musl": "1.51.0", "@oxlint/binding-openharmony-arm64": "1.51.0", "@oxlint/binding-win32-arm64-msvc": "1.51.0", "@oxlint/binding-win32-ia32-msvc": "1.51.0", "@oxlint/binding-win32-x64-msvc": "1.51.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.15.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-g6DNPaV9/WI9MoX2XllafxQuxwY1TV++j7hP8fTJByVBuCoVtm3dy9f/2vtH/HU40JztcgWF4G7ua+gkainklQ=="],
 
     "oxlint-tsgolint": ["oxlint-tsgolint@0.15.0", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.15.0", "@oxlint-tsgolint/darwin-x64": "0.15.0", "@oxlint-tsgolint/linux-arm64": "0.15.0", "@oxlint-tsgolint/linux-x64": "0.15.0", "@oxlint-tsgolint/win32-arm64": "0.15.0", "@oxlint-tsgolint/win32-x64": "0.15.0" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-iwvFmhKQVZzVTFygUVI4t2S/VKEm+Mqkw3jQRJwfDuTcUYI5LCIYzdO5Dbuv4mFOkXZCcXaRRh0m+uydB5xdqw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "tsgolint": ["tsgolint@0.0.1", "", {}, "sha512-cSh6jgqMsVrzaRipcTBDcfiUo3iTK92gukInY0eeFP14ICe1pZjBC+yL1rVfQSBR72ZaBizmwsqEI4g1eqx1Eg=="],
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "marked": "^17.0.5",
     "oxlint": "^1.51.0",
     "oxlint-tsgolint": "^0.15.0",
+    "playwright-core": "^1.59.1",
     "tsgolint": "^0.0.1",
     "typescript": "6.0.2"
   }

--- a/scripts/browser-automation.ts
+++ b/scripts/browser-automation.ts
@@ -3,6 +3,7 @@ import { closeSync, mkdirSync, mkdtempSync, openSync, readFileSync, rmSync, writ
 import { createConnection, createServer as createNetServer } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import type { Browser as PlaywrightBrowser, BrowserContext as PlaywrightBrowserContext, Page as PlaywrightPage } from 'playwright-core'
 import { readNavigationPhaseState, readNavigationReportText, type NavigationPhase } from '../shared/navigation-state.ts'
 
 export type BrowserKind = 'chrome' | 'safari' | 'firefox'
@@ -28,6 +29,20 @@ export type PageServer = {
 export type BrowserAutomationLock = {
   release: () => void
 }
+
+type ChromeAutomationDriver = 'apple-script' | 'playwright'
+
+type PlaywrightChromeSessionState = {
+  browser: PlaywrightBrowser
+  context: PlaywrightBrowserContext
+  page: PlaywrightPage
+}
+
+const PLAYWRIGHT_CHROME_EXECUTABLE = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+const PLAYWRIGHT_CHROME_VIEWPORT = { width: 1512, height: 762 } as const
+const PLAYWRIGHT_CHROME_SCREEN = { width: 1512, height: 982 } as const
+const PLAYWRIGHT_CHROME_DEVICE_SCALE_FACTOR = 2
+const PLAYWRIGHT_CHROME_SCREEN_INFO = '--screen-info={3024x1964 devicePixelRatio=2}'
 
 function runAppleScript(lines: string[]): string {
   return execFileSync(
@@ -65,6 +80,23 @@ function runBackgroundAppleScript(lines: string[]): string {
   } finally {
     restoreFrontmostApplication(frontmost)
   }
+}
+
+function getChromeAutomationDriver(options: BrowserSessionOptions): ChromeAutomationDriver {
+  const raw = (process.env['CHROME_AUTOMATION_DRIVER'] ?? 'apple-script').trim().toLowerCase()
+
+  if (raw === '' || raw === 'apple-script') {
+    return 'apple-script'
+  }
+
+  if (raw === 'playwright') {
+    if (options.foreground === true) {
+      throw new Error('CHROME_AUTOMATION_DRIVER=playwright does not support foreground runs; use AppleScript for benchmarks')
+    }
+    return 'playwright'
+  }
+
+  throw new Error(`Unsupported CHROME_AUTOMATION_DRIVER=${raw}; expected apple-script or playwright`)
 }
 
 export function sleep(ms: number): Promise<void> {
@@ -410,6 +442,125 @@ async function initializeFirefoxSession(): Promise<FirefoxSessionState> {
   }
 }
 
+async function loadPlaywrightChromium(): Promise<{
+  launch: (options: {
+    headless: boolean
+    executablePath: string
+    args: string[]
+  }) => Promise<PlaywrightBrowser>
+}> {
+  try {
+    const module = await import('playwright-core')
+    return module.chromium
+  } catch (error) {
+    throw new Error(
+      `CHROME_AUTOMATION_DRIVER=playwright requires playwright-core to be installed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    )
+  }
+}
+
+type PlaywrightChromeEnvironment = {
+  innerWidth: number
+  innerHeight: number
+  screenWidth: number
+  screenHeight: number
+  dpr: number
+}
+
+async function readPlaywrightChromeEnvironment(page: PlaywrightPage): Promise<PlaywrightChromeEnvironment> {
+  return await page.evaluate(() => ({
+    innerWidth: window.innerWidth,
+    innerHeight: window.innerHeight,
+    screenWidth: window.screen.width,
+    screenHeight: window.screen.height,
+    dpr: window.devicePixelRatio,
+  }))
+}
+
+function formatPlaywrightChromeEnvironment(env: PlaywrightChromeEnvironment): string {
+  return `${env.innerWidth}x${env.innerHeight} screen=${env.screenWidth}x${env.screenHeight} dpr=${env.dpr}`
+}
+
+async function assertPlaywrightChromeEnvironment(page: PlaywrightPage): Promise<void> {
+  const env = await readPlaywrightChromeEnvironment(page)
+  const matches =
+    env.innerWidth === PLAYWRIGHT_CHROME_VIEWPORT.width &&
+    env.innerHeight === PLAYWRIGHT_CHROME_VIEWPORT.height &&
+    env.screenWidth === PLAYWRIGHT_CHROME_SCREEN.width &&
+    env.screenHeight === PLAYWRIGHT_CHROME_SCREEN.height &&
+    env.dpr === PLAYWRIGHT_CHROME_DEVICE_SCALE_FACTOR
+
+  if (matches) return
+
+  throw new Error(
+    `Pinned Playwright Chrome environment mismatch: expected ${PLAYWRIGHT_CHROME_VIEWPORT.width}x${PLAYWRIGHT_CHROME_VIEWPORT.height} screen=${PLAYWRIGHT_CHROME_SCREEN.width}x${PLAYWRIGHT_CHROME_SCREEN.height} dpr=${PLAYWRIGHT_CHROME_DEVICE_SCALE_FACTOR}, got ${formatPlaywrightChromeEnvironment(env)}`,
+  )
+}
+
+async function initializePlaywrightChromeSession(): Promise<PlaywrightChromeSessionState> {
+  const chromium = await loadPlaywrightChromium()
+  const browser = await chromium.launch({
+    headless: true,
+    executablePath: PLAYWRIGHT_CHROME_EXECUTABLE,
+    args: [PLAYWRIGHT_CHROME_SCREEN_INFO],
+  })
+
+  try {
+    const context = await browser.newContext({
+      viewport: PLAYWRIGHT_CHROME_VIEWPORT,
+      screen: PLAYWRIGHT_CHROME_SCREEN,
+      deviceScaleFactor: PLAYWRIGHT_CHROME_DEVICE_SCALE_FACTOR,
+    })
+    const page = await context.newPage()
+    return { browser, context, page }
+  } catch (error) {
+    await browser.close().catch(() => {})
+    throw error
+  }
+}
+
+function closePlaywrightChromeSessionState(state: PlaywrightChromeSessionState): void {
+  void state.context.close().catch(() => {})
+  void state.browser.close().catch(() => {})
+}
+
+function createPlaywrightChromeSession(): BrowserSession {
+  let statePromise: Promise<PlaywrightChromeSessionState> | null = null
+  let closed = false
+
+  function ensureState(): Promise<PlaywrightChromeSessionState> {
+    if (closed) {
+      return Promise.reject(new Error('Playwright Chrome automation session already closed'))
+    }
+    statePromise ??= initializePlaywrightChromeSession()
+    return statePromise
+  }
+
+  return {
+    async navigate(url) {
+      const state = await ensureState()
+      await state.page.goto(url, { waitUntil: 'load' })
+      await assertPlaywrightChromeEnvironment(state.page)
+    },
+    async readLocationUrl() {
+      try {
+        const state = await ensureState()
+        return state.page.url()
+      } catch {
+        return ''
+      }
+    },
+    close() {
+      if (closed) return
+      closed = true
+      if (statePromise === null) return
+      void statePromise.then(closePlaywrightChromeSessionState, () => {})
+    },
+  }
+}
+
 function createSafariSession(options: BrowserSessionOptions): BrowserSession {
   const scriptLines = ['tell application "Safari"']
 
@@ -476,6 +627,10 @@ function createSafariSession(options: BrowserSessionOptions): BrowserSession {
 }
 
 function createChromeSession(options: BrowserSessionOptions): BrowserSession {
+  if (getChromeAutomationDriver(options) === 'playwright') {
+    return createPlaywrightChromeSession()
+  }
+
   const scriptLines = [
     'tell application "Google Chrome"',
     'if (count of windows) = 0 then make new window',


### PR DESCRIPTION
## Summary

- add an optional Chrome-only Playwright correctness driver behind `CHROME_AUTOMATION_DRIVER=playwright`
- pin headless Chrome to the validated screen environment instead of silently trusting default headless layout
- keep benchmark runs on the existing foreground AppleScript path and fail loudly if someone tries to use the Playwright path there

## Rationale

We now have a mechanically checked-in Chrome correctness baseline in `corpora/chrome-step10.json`, so we can evaluate a new browser driver by generating the same machine-readable sweep and diffing it directly.

That made Chrome a good candidate for trying Playwright:

- Chrome correctness currently goes through AppleScript, which causes focus blips and is less pleasant for day-to-day work
- Firefox was already on a protocol path, so it did not have the same upside
- Safari still needs to stay real Safari, so Playwright WebKit is not a drop-in replacement there

The important constraint is that this is only for correctness, not benchmarks.

During the investigation:

- plain headless Chrome diverged from the checked-in corpus status
- headed Playwright Chrome matched corpus status, but benchmark numbers came back systematically slower than the current benchmark snapshot
- pinned headless Chrome with a validated screen environment matched corpus status exactly

So this PR takes the conservative split:

- Chrome correctness: optional Playwright path
- Chrome benchmarks: unchanged AppleScript foreground path
- no silent fallback between the two

## Implementation notes

- the Playwright path is only selected when `CHROME_AUTOMATION_DRIVER=playwright`
- it is Chrome-only and non-foreground only
- it uses headless Chrome with `--screen-info={3024x1964 devicePixelRatio=2}`
- it asserts the pinned environment from inside the page before trusting the run
- benchmark callers still pass `foreground: true`, so the Playwright path errors immediately there

## Verification

- `bun run check`
- `CHROME_AUTOMATION_DRIVER=playwright bun run accuracy-check` → `7680/7680`
- `CHROME_AUTOMATION_DRIVER=playwright bun run corpus-sweep --all --start=300 --end=900 --step=10 --output=/tmp/pretext-playwright-step10-pr.json`
- mechanical diff of `/tmp/pretext-playwright-step10-pr.json` against `corpora/chrome-step10.json` → `0` diffs
- `CHROME_AUTOMATION_DRIVER=playwright bun run benchmark-check` fails loudly with the expected guardrail message

## Follow-up questions

- whether to add convenience scripts for the Playwright correctness path
- whether this should stay opt-in indefinitely or become the default Chrome correctness driver later
