### PR TITLE
Use localhost for Windows start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "status-dashboard": "bun run scripts/status-dashboard.ts",
     "site:build": "rm -rf site && bun run scripts/build-demo-site.ts",
     "start": "HOST=${HOST:-0.0.0.0}; PORT=3000; pids=$(lsof -tiTCP:$PORT -sTCP:LISTEN 2>/dev/null); if [ -n \"$pids\" ]; then echo \"Freeing port $PORT: terminating $pids\"; kill $pids 2>/dev/null || true; sleep 1; pids=$(lsof -tiTCP:$PORT -sTCP:LISTEN 2>/dev/null); if [ -n \"$pids\" ]; then echo \"Port $PORT still busy: killing $pids\"; kill -9 $pids 2>/dev/null || true; fi; fi; bun pages/*.html pages/demos/*.html pages/demos/*/index.html --host=$HOST:$PORT",
-    "start:windows": "bun pages/*.html pages/demos/*.html pages/demos/*/index.html --host=0.0.0.0:3000"
+    "start:windows": "bun pages/*.html pages/demos/*.html pages/demos/*/index.html --host=127.0.0.1:3000"
   },
   "devDependencies": {
     "@types/bun": "latest",


### PR DESCRIPTION
Update package.json start:windows script to bind the dev server to 127.0.0.1 instead of 0.0.0.0. This restricts the Windows development server to localhost, preventing it from listening on all interfaces and reducing accidental external exposure.