### PR TITLE
perf: skip no-op merge passes in analysis pipeline

### DIFF
--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -524,6 +524,15 @@ function isUrlQueryBoundarySegment(text: string): boolean {
 }
 
 function mergeUrlLikeRuns(segmentation: MergedSegmentation): MergedSegmentation {
+  let hasUrlStart = false
+  for (let i = 0; i < segmentation.len; i++) {
+    if (segmentation.kinds[i] === 'text' && isUrlLikeRunStart(segmentation, i)) {
+      hasUrlStart = true
+      break
+    }
+  }
+  if (!hasUrlStart) return segmentation
+
   const texts = segmentation.texts.slice()
   const isWordLike = segmentation.isWordLike.slice()
   const kinds = segmentation.kinds.slice()
@@ -574,6 +583,17 @@ function mergeUrlLikeRuns(segmentation: MergedSegmentation): MergedSegmentation 
 }
 
 function mergeUrlQueryRuns(segmentation: MergedSegmentation): MergedSegmentation {
+  // Conservative guard: if no text segment looks like a URL query boundary,
+  // this pass cannot produce any change.
+  let hasQueryBoundary = false
+  for (let i = 0; i < segmentation.len; i++) {
+    if (segmentation.kinds[i] === 'text' && isUrlQueryBoundarySegment(segmentation.texts[i]!)) {
+      hasQueryBoundary = true
+      break
+    }
+  }
+  if (!hasQueryBoundary) return segmentation
+
   const texts: string[] = []
   const isWordLike: boolean[] = []
   const kinds: SegmentBreakKind[] = []
@@ -648,6 +668,16 @@ export function isNumericRunSegment(text: string): boolean {
 }
 
 function mergeNumericRuns(segmentation: MergedSegmentation): MergedSegmentation {
+  let hasNumericRun = false
+  for (let i = 0; i < segmentation.len; i++) {
+    const text = segmentation.texts[i]!
+    if (segmentation.kinds[i] === 'text' && isNumericRunSegment(text) && segmentContainsDecimalDigit(text)) {
+      hasNumericRun = true
+      break
+    }
+  }
+  if (!hasNumericRun) return segmentation
+
   const texts: string[] = []
   const isWordLike: boolean[] = []
   const kinds: SegmentBreakKind[] = []
@@ -693,6 +723,21 @@ function mergeNumericRuns(segmentation: MergedSegmentation): MergedSegmentation 
 }
 
 function mergeAsciiPunctuationChains(segmentation: MergedSegmentation): MergedSegmentation {
+  let hasChain = false
+  for (let i = 0; i < segmentation.len - 1; i++) {
+    if (
+      segmentation.kinds[i] === 'text' &&
+      segmentation.isWordLike[i] &&
+      asciiPunctuationChainTrailingJoinersRe.test(segmentation.texts[i]!) &&
+      segmentation.kinds[i + 1] === 'text' &&
+      segmentation.isWordLike[i + 1]
+    ) {
+      hasChain = true
+      break
+    }
+  }
+  if (!hasChain) return segmentation
+
   const texts: string[] = []
   const isWordLike: boolean[] = []
   const kinds: SegmentBreakKind[] = []
@@ -745,6 +790,16 @@ function mergeAsciiPunctuationChains(segmentation: MergedSegmentation): MergedSe
 }
 
 function splitHyphenatedNumericRuns(segmentation: MergedSegmentation): MergedSegmentation {
+  let hasHyphenatedNumeric = false
+  for (let i = 0; i < segmentation.len; i++) {
+    const text = segmentation.texts[i]!
+    if (segmentation.kinds[i] === 'text' && text.includes('-') && segmentContainsDecimalDigit(text)) {
+      hasHyphenatedNumeric = true
+      break
+    }
+  }
+  if (!hasHyphenatedNumeric) return segmentation
+
   const texts: string[] = []
   const isWordLike: boolean[] = []
   const kinds: SegmentBreakKind[] = []
@@ -874,6 +929,20 @@ function mergeGlueConnectedTextRuns(segmentation: MergedSegmentation): MergedSeg
 }
 
 function carryTrailingForwardStickyAcrossCJKBoundary(segmentation: MergedSegmentation): MergedSegmentation {
+  let hasAdjacentCjkText = false
+  for (let i = 0; i < segmentation.len - 1; i++) {
+    if (
+      segmentation.kinds[i] === 'text' &&
+      segmentation.kinds[i + 1] === 'text' &&
+      isCJK(segmentation.texts[i]!) &&
+      isCJK(segmentation.texts[i + 1]!)
+    ) {
+      hasAdjacentCjkText = true
+      break
+    }
+  }
+  if (!hasAdjacentCjkText) return segmentation
+
   const texts = segmentation.texts.slice()
   const isWordLike = segmentation.isWordLike.slice()
   const kinds = segmentation.kinds.slice()


### PR DESCRIPTION
## Summary

The six post-segmentation passes in `buildMergedSegmentation` unconditionally allocate and populate new output arrays even when the input contains no patterns that would trigger a merge or split. This adds a linear early-exit guard at the top of each function that returns the input segmentation unchanged when the relevant pattern is absent.

Each guard is intentionally a cheap necessary-condition scan: if the guard returns false, the pass cannot produce any change. A guard may return true when no actual merge happens (false positive), but it will never skip a pass that would have produced a change (no false negative).

## Motivation

For text that never hits a given pass — e.g. pure CJK has no URLs, no numeric runs, no ASCII punctuation chains, no hyphenated numbers — each pass still copies four arrays (`texts`, `isWordLike`, `kinds`, `starts`) element-by-element to produce identical output. The guards are O(n) with early break on first match, and in the no-op cases targeted here, they are cheaper than allocating and populating replacement arrays.

Note: `carryTrailingForwardStickyAcrossCJKBoundary` is the exception — its guard triggers *on* CJK text (adjacent CJK text pairs), so the CJK improvement comes primarily from the other five guards. This guard benefits non-CJK text that would otherwise pay for `.slice()` copies without any carries to perform.


## Changes

- `src/analysis.ts` — added early-exit guards to 6 internal functions:
  - `mergeUrlLikeRuns`: skip when no URL-like run starts exist
  - `mergeUrlQueryRuns`: skip when no URL query boundary segments exist (conservative — `isUrlQueryBoundarySegment` already requires `://` or `www.` prefix, so the guard is at least as wide as the actual merge condition)
  - `mergeNumericRuns`: skip when no numeric run segments with decimal digits exist
  - `mergeAsciiPunctuationChains`: skip when no trailing-joiner wordlike text is followed by another wordlike text (necessary condition for the inner while loop to merge anything)
  - `splitHyphenatedNumericRuns`: skip when no text contains both `-` and a decimal digit
  - `carryTrailingForwardStickyAcrossCJKBoundary`: skip when no adjacent CJK text pairs exist
- No changes to existing merge/split logic — guards only add an early return path
- No public API changes, no `layout()` hot path changes

## Benchmark

Environment: Windows 11, Bun 1.3.11, fake canvas backend.
Method: `analyzeText()` × 5000 iters, trimmed mean of 20 rounds, alternating patched (P) / original (O) across 3 independent process pairs.

**No-pattern text (guards skip all passes):**

| Text | P1 | O1 | P2 | O2 | P3 | O3 |
|------|----|----|----|----|----|----|
| Chinese 150c (µs) | 122.3 | 150.9 | 138.0 | 117.8 | 112.5 | 121.1 |
| English 150c (µs) | 39.0 | 44.4 | 38.5 | 41.2 | 34.6 | 39.8 |
| Long Chinese 1500c (µs) | 1176.4 | 1226.0 | 1231.1 | 1212.9 | 1050.5 | 1274.7 |

**Pattern-heavy text (guards pass through to existing logic):**

| Text | P1 | O1 | P2 | O2 | P3 | O3 |
|------|----|----|----|----|----|----|
| AllPatterns (µs) | 51.9 | 54.4 | 45.7 | 42.7 | 43.2 | 50.6 |
| URLs (µs) | 31.2 | 36.4 | 28.7 | 28.7 | 27.7 | 34.2 |
| AppText (µs) | 43.4 | 35.3 | 41.2 | 45.0 | 40.4 | 49.0 |

**Bottom line:** In this local benchmark, English plain prose consistently improved across all 3 pairs (~10% in the 150c case). Pattern-free CJK inputs showed improvement in most pairs. No consistent regression was observed on pattern-heavy inputs.

## Test plan

- [x] `bun test` — 84 tests pass, 0 fail
- [x] Benchmark: pattern-free text shows improvement, no worst-case regression
- [ ] Browser benchmark verification on macOS (not available to contributor)