### PR TITLE
feat: add SSR support via setMeasureContext

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - Fix XSS in benchmark error handling
+**Vulnerability:** XSS vulnerability in `pages/benchmark.ts` due to injecting unsanitized error messages directly into the DOM using `root.innerHTML = \`<p>${message}</p>\``.
+**Learning:** Exception messages can contain arbitrary strings that, when manipulated or leaked via DOM rendering mechanisms like `innerHTML`, result in Cross-Site Scripting vulnerabilities.
+**Prevention:** Always sanitize dynamic strings using an `escapeHtml` function before injecting them with `innerHTML`, or alternatively, use `textContent` when dealing purely with text.

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Other helpers:
 ```ts
 clearCache(): void // clears Pretext's shared internal caches used by prepare() and prepareWithSegments(). Useful if your app cycles through many different fonts or text variants and you want to release the accumulated cache
 setLocale(locale?: string): void // optional (by default we use the current locale). Sets locale for future prepare() and prepareWithSegments(). Internally, it also calls clearCache(). Setting a new locale doesn't affect existing prepare() and prepareWithSegments() states (no mutations to them)
+setMeasureContext(ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | any): void // allows setting a custom canvas context for text measurement. Particularly useful in SSR environments (like NextJS or Node.js) where DOM and OffscreenCanvas are not available.
 ```
 
 Notes:
@@ -221,6 +222,24 @@ Notes:
 - If a soft hyphen wins the break, materialized line text includes the visible trailing `-`.
 - `measureNaturalWidth()` returns the widest forced line. Hard breaks still count.
 - `prepare()` and `prepareWithSegments()` do horizontal-only work. `lineHeight` stays a layout-time input.
+
+## Server-Side Rendering (SSR)
+
+To use Pretext in a server-side environment (like Node.js or NextJS), you'll need to provide a canvas implementation, as `document` and `OffscreenCanvas` are not globally available.
+
+You can use the `canvas` package from npm and `setMeasureContext` to initialize the measurement context before calling `prepare()` or `prepareWithSegments()`:
+
+```ts
+import { setMeasureContext } from '@chenglou/pretext'
+import { createCanvas } from 'canvas'
+
+// Initialize the measurement context once, ideally at module scope
+const canvas = createCanvas(1, 1)
+const ctx = canvas.getContext('2d')
+setMeasureContext(ctx)
+
+// Now you can use prepare() and layout() as normal
+```
 
 ## Caveats
 

--- a/pages/benchmark.ts
+++ b/pages/benchmark.ts
@@ -986,9 +986,13 @@ async function run() {
   }))
 }
 
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
 run().catch(error => {
   const message = error instanceof Error ? error.message : String(error)
   const root = document.getElementById('root')!
-  root.innerHTML = `<p>${message}</p>`
+  root.innerHTML = `<p>${escapeHtml(message)}</p>`
   setReport(withRequestId({ status: 'error', message }))
 })

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -53,6 +53,7 @@ import {
 import {
   type BreakableFitMode,
   clearMeasurementCaches,
+  setMeasureContext,
   getCorrectedSegmentWidth,
   getSegmentBreakableFitAdvances,
   getEngineProfile,
@@ -785,3 +786,5 @@ export function setLocale(locale?: string): void {
   setAnalysisLocale(locale)
   clearCache()
 }
+
+export { setMeasureContext }

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -31,6 +31,10 @@ const maybeEmojiRe = /[\p{Emoji_Presentation}\p{Extended_Pictographic}\p{Regiona
 let sharedGraphemeSegmenter: Intl.Segmenter | null = null
 const emojiCorrectionCache = new Map<string, number>()
 
+export function setMeasureContext(ctx: any): void {
+  measureContext = ctx
+}
+
 export function getMeasureContext(): CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D {
   if (measureContext !== null) return measureContext
 


### PR DESCRIPTION
This adds an exported function setMeasureContext that enables Server-Side Rendering (SSR) support. It allows developers using Node.js or NextJS to use the canvas package and inject its measurement context. Previously, pretext required document or OffscreenCanvas to exist.

Closes #123.