### PR TITLE
fix: preserve streamed line starts inside a chunk

### DIFF
--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -818,6 +818,30 @@ describe('layout invariants', () => {
     expect(actual).toEqual(expected.lines)
   })
 
+  test('streaming canary preserves exact continuation cursors after a ZWSP break opportunity', () => {
+    const text = 'بام  \u200DB     bا \u00ADb\u060C b\f \u061F🚀\u061Fع ر 本 \u061F\na a A\u200B 語 語\u200Dح'
+    const prepared = prepareWithSegments(text, FONT)
+    const width = 56.57
+    const expected = layoutWithLines(prepared, width, LINE_HEIGHT)
+
+    expect(collectStreamedLines(prepared, width)).toEqual(expected.lines)
+
+    const streamedRanges = []
+    let cursor = { segmentIndex: 0, graphemeIndex: 0 }
+    while (true) {
+      const line = layoutNextLineRange(prepared, cursor, width)
+      if (line === null) break
+      streamedRanges.push(line)
+      cursor = line.end
+    }
+
+    expect(streamedRanges).toEqual(expected.lines.map(line => ({
+      width: line.width,
+      start: line.start,
+      end: line.end,
+    })))
+  })
+
   test('layout and layoutWithLines stay aligned when ZWSP triggers narrow grapheme breaking', () => {
     const cases = [
       'alpha\u200Bbeta',

--- a/src/line-break.ts
+++ b/src/line-break.ts
@@ -42,6 +42,8 @@ function normalizeSimpleLineStartSegmentIndex(
   prepared: PreparedLineBreakData,
   segmentIndex: number,
 ): number {
+  if (segmentIndex > 0) return segmentIndex
+
   while (segmentIndex < prepared.widths.length) {
     const kind = prepared.kinds[segmentIndex]!
     if (kind !== 'space' && kind !== 'zero-width-break' && kind !== 'soft-hyphen') break
@@ -113,6 +115,12 @@ function normalizeLineStartInChunk(
   }
 
   if (segmentIndex < chunk.startSegmentIndex) segmentIndex = chunk.startSegmentIndex
+  if (segmentIndex > chunk.startSegmentIndex) {
+    cursor.segmentIndex = segmentIndex
+    cursor.graphemeIndex = 0
+    return chunkIndex
+  }
+
   while (segmentIndex < chunk.endSegmentIndex) {
     const kind = prepared.kinds[segmentIndex]!
     if (kind !== 'space' && kind !== 'zero-width-break' && kind !== 'soft-hyphen') {


### PR DESCRIPTION
## Problem
`layoutNextLine()` and `layoutNextLineRange()` renormalize every continuation cursor as if it were starting from a fresh paragraph or chunk boundary. In mixed-script edge cases with a `ZWSP` break opportunity followed by collapsible whitespace, that can skip a real continuation segment and merge two streamed lines that `layoutWithLines()` keeps separate.

## Root Cause
The line-start normalization helpers unconditionally skipped `space`, `zero-width-break`, and `soft-hyphen` segments even when the caller was resuming from an exact `end` cursor returned by the previous streamed line. That normalization is correct at the true start of a paragraph or chunk, but it is too aggressive for continuation cursors inside an existing chunk.

## Fix
Only trim collapsible leading break-opportunity segments when the cursor is at the true paragraph start or chunk start. If the caller resumes from a later in-chunk cursor, preserve it exactly and continue streaming from that segment.

## Validation
- `cd /tmp/pretext_issue_121 && ~/.bun/bin/bun test src/layout.test.ts --test-name-pattern 'streaming canary preserves exact continuation cursors after a ZWSP break opportunity|layoutWithLines strips leading collapsible space after a ZWSP break the same way as layoutNextLine|layoutNextLine reproduces layoutWithLines exactly'`
- `cd /tmp/pretext_issue_121 && ~/.bun/bin/bun test src/layout.test.ts`

Closes #121
