### PR TITLE
Add Mouse & Cheese demo 

### DIFF
--- a/pages/demos/index.html
+++ b/pages/demos/index.html
@@ -141,6 +141,11 @@
         <h2>Masonry</h2>
         <p>A text-card occlusion demo where height prediction comes from Pretext instead of DOM reads.</p>
       </a>
+
+      <a class="card" href="/demos/mouse-cheese">
+        <h2>Mouse &amp; Cheese</h2>
+        <p>A story that wraps around a cheese obstacle in real time — resize the cheese, watch the lines reflow.</p>
+      </a>
     </section>
   </main>
 </body>

--- a/pages/demos/mouse-cheese.html
+++ b/pages/demos/mouse-cheese.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mouse &amp; Cheese — Pretext Demo</title>
+<style>
+  * { box-sizing: border-box; }
+  :root {
+    color-scheme: light;
+    --page: #f5f1ea;
+    --panel: #fffdf8;
+    --ink: #201b18;
+    --muted: #6d645d;
+    --rule: #d8cec3;
+    --accent: #955f3b;
+    --accent-soft: #f0e4da;
+    --cheese-size: 140px;
+  }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: radial-gradient(circle at top, #fff8f1 0, var(--page) 42%, #efe8de 100%);
+    background-color: #efe8de;
+    background-repeat: no-repeat;
+    color: var(--ink);
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  }
+  .page {
+    width: min(780px, calc(100vw - 32px));
+    margin: 0 auto;
+    padding: 32px 0 48px;
+  }
+  .eyebrow {
+    margin: 0 0 8px;
+    font: 12px/1.2 "SF Mono", ui-monospace, monospace;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent);
+  }
+  h1 {
+    margin: 0;
+    font: 700 32px/1.08 Georgia, "Times New Roman", serif;
+  }
+  .intro {
+    margin: 10px 0 0;
+    max-width: 60ch;
+    line-height: 1.5;
+    color: var(--muted);
+  }
+  .controls {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin: 24px 0 16px;
+    padding: 14px 18px;
+    border: 1px solid var(--rule);
+    border-radius: 18px;
+    background: color-mix(in srgb, var(--panel) 92%, white 8%);
+    box-shadow: 0 18px 40px rgb(54 40 23 / 0.08);
+    font: 12px/1.2 "SF Mono", ui-monospace, monospace;
+    color: var(--muted);
+  }
+  .controls input[type=range] {
+    flex: 1;
+    accent-color: var(--accent);
+  }
+  .controls .val {
+    min-width: 52px;
+    text-align: right;
+    color: var(--ink);
+  }
+  .panel {
+    position: relative;
+    padding: 28px 28px 28px;
+    border: 1px solid var(--rule);
+    border-radius: 20px;
+    background: color-mix(in srgb, var(--panel) 92%, white 8%);
+    box-shadow: 0 18px 40px rgb(54 40 23 / 0.08);
+    min-height: 380px;
+    overflow: hidden;
+  }
+  /* The text layer: all story lines rendered here by JS */
+  .text-layer {
+    position: relative;
+    font: 16px/26px "Helvetica Neue", Helvetica, Arial, sans-serif;
+    color: var(--ink);
+  }
+  /* Cheese block: absolute, top-right of the panel */
+  .cheese-wrap {
+    position: absolute;
+    top: 28px;
+    right: 28px;
+    width: var(--cheese-size);
+    height: var(--cheese-size);
+    transition: width 80ms ease, height 80ms ease;
+    pointer-events: none;
+  }
+  .cheese-wrap svg {
+    width: 100%;
+    height: 100%;
+  }
+  /* Mouse: fixed bottom-right of the panel */
+  .mouse-wrap {
+    position: absolute;
+    bottom: 12px;
+    right: 20px;
+    width: 96px;
+    height: 84px;
+    pointer-events: none;
+    overflow: visible;
+  }
+  .mouse-wrap svg {
+    width: 100%;
+    height: 100%;
+    overflow: visible;
+  }
+  @media (max-width: 640px) {
+    .page {
+      width: min(100vw - 20px, 780px);
+      padding-top: 22px;
+    }
+    .controls {
+      flex-wrap: wrap;
+    }
+  }
+</style>
+</head>
+<body>
+  <main class="page">
+    <p class="eyebrow">Demo</p>
+    <h1>Mouse &amp; Cheese</h1>
+    <p class="intro">
+      The story text wraps around the cheese in real time — no DOM measurements
+      in the layout path. Drag the slider to resize the cheese and watch the
+      lines reflow.
+    </p>
+
+    <section class="controls" aria-label="Cheese size control">
+      <span>Cheese size:</span>
+      <input type="range" id="cheese-slider" min="60" max="240" value="140">
+      <span class="val" id="cheese-size-label">140px</span>
+    </section>
+
+    <section class="panel" id="scene" aria-label="Mouse and cheese scene">
+      <!-- Text lines injected here by mouse-cheese.ts -->
+      <div class="text-layer" id="text-layer"></div>
+
+      <!-- Cheese illustration (scalable) -->
+      <div class="cheese-wrap" id="cheese-wrap">
+        <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <!-- Shadow -->
+          <ellipse cx="52" cy="95" rx="36" ry="5" fill="#D4A017" opacity="0.25"/>
+          <!-- Main cheese body -->
+          <rect x="6" y="8" width="88" height="82" rx="14" fill="#F4C43A"/>
+          <!-- Top highlight band -->
+          <rect x="6" y="8" width="88" height="22" rx="14" fill="#FAE168" opacity="0.55"/>
+          <rect x="6" y="22" width="88" height="8" fill="#FAE168" opacity="0.55"/>
+          <!-- Cheese holes -->
+          <ellipse cx="28" cy="36" rx="12" ry="10" fill="#FAD95C" stroke="#D4A017" stroke-width="1.5"/>
+          <ellipse cx="66" cy="50" rx="9" ry="8" fill="#FAD95C" stroke="#D4A017" stroke-width="1.5"/>
+          <ellipse cx="40" cy="68" rx="10" ry="9" fill="#FAD95C" stroke="#D4A017" stroke-width="1.5"/>
+          <!-- Hole inner shadows (depth effect) -->
+          <ellipse cx="28" cy="37" rx="10" ry="8" fill="none" stroke="#D4A017" stroke-width="1" opacity="0.4"/>
+          <ellipse cx="66" cy="51" rx="7" ry="6" fill="none" stroke="#D4A017" stroke-width="1" opacity="0.4"/>
+          <ellipse cx="40" cy="69" rx="8" ry="7" fill="none" stroke="#D4A017" stroke-width="1" opacity="0.4"/>
+          <!-- Outer border -->
+          <rect x="6" y="8" width="88" height="82" rx="14" fill="none" stroke="#D4A017" stroke-width="2.5"/>
+        </svg>
+      </div>
+
+      <!-- Mouse illustration (fixed position, bottom-right) -->
+      <div class="mouse-wrap" id="mouse-wrap" aria-hidden="true">
+        <svg viewBox="-8 0 108 84" xmlns="http://www.w3.org/2000/svg">
+          <!-- Tail -->
+          <path d="M 88 54 Q 96 70 82 73 Q 68 76 64 64" fill="none" stroke="#BDBDBD" stroke-width="3.5" stroke-linecap="round"/>
+          <!-- Body -->
+          <ellipse cx="62" cy="52" rx="28" ry="21" fill="#ABABAB"/>
+          <!-- Body highlight -->
+          <ellipse cx="54" cy="43" rx="14" ry="8" fill="#C4C4C4" opacity="0.6"/>
+          <!-- Head -->
+          <circle cx="30" cy="44" r="20" fill="#ABABAB"/>
+          <!-- Head highlight -->
+          <circle cx="26" cy="37" r="9" fill="#C4C4C4" opacity="0.5"/>
+          <!-- Left ear (back) -->
+          <circle cx="20" cy="23" r="11" fill="#ABABAB"/>
+          <!-- Right ear -->
+          <circle cx="40" cy="21" r="11" fill="#ABABAB"/>
+          <!-- Inner left ear -->
+          <circle cx="20" cy="23" r="7" fill="#F8BBD0"/>
+          <!-- Inner right ear -->
+          <circle cx="40" cy="21" r="7" fill="#F8BBD0"/>
+          <!-- Eye -->
+          <circle cx="20" cy="40" r="4" fill="#1a1a1a"/>
+          <circle cx="21" cy="39" r="1.5" fill="white"/>
+          <!-- Nose -->
+          <circle cx="11" cy="46" r="3.5" fill="#F48FB1"/>
+          <!-- Whiskers left-upper -->
+          <line x1="11" y1="44" x2="-6" y2="38" stroke="#777" stroke-width="1.2" stroke-linecap="round"/>
+          <line x1="11" y1="46" x2="-8" y2="46" stroke="#777" stroke-width="1.2" stroke-linecap="round"/>
+          <line x1="11" y1="48" x2="-6" y2="54" stroke="#777" stroke-width="1.2" stroke-linecap="round"/>
+          <!-- Whiskers right-upper -->
+          <line x1="11" y1="44" x2="24" y2="38" stroke="#777" stroke-width="1.2" stroke-linecap="round"/>
+          <line x1="11" y1="46" x2="26" y2="46" stroke="#777" stroke-width="1.2" stroke-linecap="round"/>
+          <line x1="11" y1="48" x2="24" y2="54" stroke="#777" stroke-width="1.2" stroke-linecap="round"/>
+          <!-- Mouth -->
+          <path d="M 11 49 Q 14 52 17 49" fill="none" stroke="#888" stroke-width="1.2" stroke-linecap="round"/>
+        </svg>
+      </div>
+    </section>
+  </main>
+
+  <script type="module" src="./mouse-cheese.ts"></script>
+</body>
+</html>

--- a/pages/demos/mouse-cheese.ts
+++ b/pages/demos/mouse-cheese.ts
@@ -1,0 +1,181 @@
+import { prepareWithSegments, layoutNextLine, type LayoutCursor, type PreparedTextWithSegments } from '../../src/layout.ts'
+
+const STORY =
+  'Once upon a time, a very hungry mouse crept through a quiet kitchen. ' +
+  'His tiny nose twitched with the unmistakable scent of aged Gruyère. ' +
+  'There, on the wooden counter, sat the most magnificent wedge of cheese ' +
+  'he had ever seen — golden, dotted with perfect round holes, glowing like ' +
+  'a small sun in the afternoon light. He froze. His whiskers quivered. His ' +
+  'heart thumped like a tiny drum. Could this be real? He had dreamed of such ' +
+  'a cheese every night, curled up in his little nest behind the baseboard. ' +
+  'Round. Warm. Salty. Perfect. He took one careful step forward, then another. ' +
+  'The cheese did not move. He took one deep breath and made a decision: ' +
+  'today, at long last, the cheese would be his.'
+
+// Gap between the right edge of the text and the left edge of the cheese
+const CHEESE_GAP = 14
+// Padding inside the panel (must match the CSS padding on .panel)
+const PANEL_PADDING = 28
+// Line height — must match the CSS on .text-layer (16px/26px)
+const LINE_H = 26
+
+type State = {
+  scheduledRaf: number | null
+  prepared: PreparedTextWithSegments | null
+  preparedFont: string
+}
+
+const st: State = {
+  scheduledRaf: null,
+  prepared: null,
+  preparedFont: '',
+}
+
+function getRequiredElement(id: string): HTMLElement {
+  const el = document.getElementById(id)
+  if (!(el instanceof HTMLElement)) throw new Error(`#${id} not found`)
+  return el
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', boot, { once: true })
+} else {
+  boot()
+}
+
+function boot(): void {
+  const slider = getRequiredElement('cheese-slider')
+  const scene = getRequiredElement('scene')
+  const cheeseWrap = getRequiredElement('cheese-wrap')
+  const textLayer = getRequiredElement('text-layer')
+  const sizeLabel = getRequiredElement('cheese-size-label')
+
+  if (!(slider instanceof HTMLInputElement)) return
+
+  function scheduleRender(): void {
+    if (st.scheduledRaf !== null) return
+    st.scheduledRaf = requestAnimationFrame(() => {
+      st.scheduledRaf = null
+      render(slider, scene, cheeseWrap, textLayer, sizeLabel)
+    })
+  }
+
+  slider.addEventListener('input', () => {
+    sizeLabel.textContent = `${slider.value}px`
+    scheduleRender()
+  })
+
+  window.addEventListener('resize', scheduleRender)
+
+  document.fonts.ready.then(() => {
+    scheduleRender()
+  })
+
+  scheduleRender()
+}
+
+function getFontString(el: HTMLElement): string {
+  const styles = getComputedStyle(el)
+  if (styles.font.length > 0) return styles.font
+  return (
+    `${styles.fontStyle} ${styles.fontVariant} ${styles.fontWeight} ` +
+    `${styles.fontSize} / ${styles.lineHeight} ${styles.fontFamily}`
+  )
+}
+
+function getPrepared(font: string): PreparedTextWithSegments {
+  if (st.prepared !== null && st.preparedFont === font) return st.prepared
+  st.preparedFont = font
+  st.prepared = prepareWithSegments(STORY, font)
+  return st.prepared
+}
+
+function availableWidth(
+  lineY: number,
+  containerW: number,
+  cheeseTop: number,
+  cheeseBottom: number,
+  cheeseLeft: number,
+): number {
+  const lineBottom = lineY + LINE_H
+  if (lineY < cheeseBottom && lineBottom > cheeseTop) {
+    // This line overlaps the cheese vertically — narrow it so text stays left of cheese
+    return Math.max(60, cheeseLeft - CHEESE_GAP)
+  }
+  return containerW
+}
+
+function render(
+  slider: HTMLInputElement,
+  scene: HTMLElement,
+  cheeseWrap: HTMLElement,
+  textLayer: HTMLElement,
+  sizeLabel: HTMLElement,
+): void {
+  const sceneRect = scene.getBoundingClientRect()
+  const containerW = Math.floor(sceneRect.width) - PANEL_PADDING * 2
+  if (containerW < 60) return
+
+  const cheeseSize = Number(slider.value)
+  sizeLabel.textContent = `${cheeseSize}px`
+
+  // Cheese position relative to the text layer (top-right of the panel content area)
+  const CHEESE_TOP = 0    // cheese starts at the top of the text area
+  const cheeseBottom = CHEESE_TOP + cheeseSize
+  const cheeseLeft = containerW - cheeseSize  // right-flush within the content area
+
+  // Update the cheese element size (CSS custom property on the panel)
+  scene.style.setProperty('--cheese-size', `${cheeseSize}px`)
+
+  // Get the font from the text layer so Pretext uses the same face/size the browser renders
+  const font = getFontString(textLayer)
+  const prepared = getPrepared(font)
+
+  // Walk lines with per-line widths using layoutNextLine()
+  let cursor: LayoutCursor = { segmentIndex: 0, graphemeIndex: 0 }
+  let y = 0
+  const lines: Array<{ text: string; y: number; w: number }> = []
+
+  while (true) {
+    const w = availableWidth(y, containerW, CHEESE_TOP, cheeseBottom, cheeseLeft)
+    const line = layoutNextLine(prepared, cursor, w)
+    if (line === null) break
+    lines.push({ text: line.text, y, w })
+    cursor = line.end
+    y += LINE_H
+    if (y > 1200) break // safety cap
+  }
+
+  // Flush lines into DOM — reuse existing span elements where possible
+  const children = textLayer.children
+  const childArray = Array.from(children) as HTMLElement[]
+
+  for (let i = 0; i < lines.length; i++) {
+    const lineData = lines[i]!
+    let el = childArray[i]
+    if (!(el instanceof HTMLSpanElement)) {
+      el = document.createElement('span')
+      el.style.cssText =
+        'display:block;position:absolute;left:0;white-space:nowrap;overflow:visible;'
+      textLayer.appendChild(el)
+      childArray.push(el)
+    }
+    el.textContent = lineData.text
+    el.style.top = `${lineData.y}px`
+    el.hidden = false
+  }
+
+  // Hide any extra spans from a previous render with more lines
+  for (let i = lines.length; i < childArray.length; i++) {
+    const el = childArray[i]
+    if (el instanceof HTMLElement) el.hidden = true
+  }
+
+  // Size the text layer so the panel is tall enough
+  const textHeight = y
+  textLayer.style.height = `${textHeight}px`
+
+  // Ensure the panel is tall enough to show text + mouse illustration
+  const minPanelHeight = textHeight + PANEL_PADDING * 2 + 20
+  scene.style.minHeight = `${Math.max(380, minPanelHeight)}px`
+}


### PR DESCRIPTION
A new demo page (/demos/mouse-cheese) showing Pretext's layoutNextLine() used for per-line variable-width layout: each story line gets a narrower available width while it overlaps the cheese block, so the text naturally wraps around the illustration. A slider resizes the cheese in real time and the text reflows without any DOM measurements in the resize path.

The cheese and mouse are inline SVGs (cute cartoon style). The demo is added to the demos index grid alongside the existing nine demos.

https://claude.ai/code/session_01P3CMU8eN1riSUg4EzCaMcA