### PR TITLE
fix: sync streaming line-break stepper with batch walker

### DIFF
--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -1043,6 +1043,37 @@ describe('layout invariants', () => {
     expect(actual).toEqual(expected.lines)
   })
 
+  test('pre-wrap soft-hyphen does not preempt a closer breakAfter opportunity', () => {
+    // When a soft-hyphen pending break and a preserved-space breakAfter are
+    // both available, the breakAfter (which allows more content on the line)
+    // should win — matching the batch walker's check order.
+    const prepared = prepareWithSegments('A\nbا \u00ADb، b', FONT, { whiteSpace: 'pre-wrap' })
+    const width = measureWidth('bا', FONT) + measureWidth(' ', FONT) + measureWidth('b،', FONT) + measureWidth(' ', FONT) + 0.1
+    const expected = layoutWithLines(prepared, width, LINE_HEIGHT)
+    expect(collectStreamedLines(prepared, width)).toEqual(expected.lines)
+  })
+
+  test('layoutNextLine keeps leading space inside a non-simple chunk when the batch walker does', () => {
+    // After a ZWSP + space break, the chunked batch walker starts the next
+    // line at the space segment without stripping it.  The streaming stepper
+    // must match by not normalizing away that leading space.
+    const prepared = prepareWithSegments('a a A\u200B 語 語\u200Dح', FONT)
+    const width = measureWidth('a', FONT) + measureWidth(' ', FONT) + measureWidth('a', FONT) + measureWidth(' ', FONT) + measureWidth('A', FONT) + measureWidth('', FONT) + 0.1
+    const expected = layoutWithLines(prepared, width, LINE_HEIGHT)
+    expect(collectStreamedLines(prepared, width)).toEqual(expected.lines)
+  })
+
+  test('mixed-script Arabic+CJK text keeps streaming aligned with batch layout', () => {
+    // Full round-trip alignment check using the reproducer from issue #121.
+    const text = 'بام  \u200DB     bا \u00ADb\u060C b\f \u061F\uD83D\uDE80\u061F\u0639 \u0631 \u672C \u061F\na a A\u200B \u8A9E \u8A9E\u200D\u062D'
+    for (const whiteSpace of ['normal', 'pre-wrap'] as const) {
+      const prepared = prepareWithSegments(text, FONT, { whiteSpace })
+      const width = 56.57
+      const expected = layoutWithLines(prepared, width, LINE_HEIGHT)
+      expect(collectStreamedLines(prepared, width)).toEqual(expected.lines)
+    }
+  })
+
   test('pre-wrap mode keeps empty lines from consecutive hard breaks', () => {
     const prepared = prepareWithSegments('\n\n', FONT, { whiteSpace: 'pre-wrap' })
     const lines = layoutWithLines(prepared, 200, LINE_HEIGHT)

--- a/src/line-break.ts
+++ b/src/line-break.ts
@@ -113,9 +113,16 @@ function normalizeLineStartInChunk(
   }
 
   if (segmentIndex < chunk.startSegmentIndex) segmentIndex = chunk.startSegmentIndex
+  // The simple fast path skips collapsible whitespace (space, zero-width-break,
+  // soft-hyphen) at line starts, matching `normalizeSimpleLineStartSegmentIndex`
+  // and the simple batch walker.  The chunked path only skips zero-width and
+  // soft-hyphen markers; regular spaces are kept because the chunked batch
+  // walker (`walkPreparedLinesRaw` non-simple branch) starts new lines at
+  // whatever segment follows the break without stripping spaces.
+  const skipSpace = prepared.simpleLineWalkFastPath
   while (segmentIndex < chunk.endSegmentIndex) {
     const kind = prepared.kinds[segmentIndex]!
-    if (kind !== 'space' && kind !== 'zero-width-break' && kind !== 'soft-hyphen') {
+    if (kind !== 'zero-width-break' && kind !== 'soft-hyphen' && (kind !== 'space' || !skipSpace)) {
       cursor.segmentIndex = segmentIndex
       cursor.graphemeIndex = 0
       return chunkIndex
@@ -791,10 +798,10 @@ function stepPreparedChunkLineGeometry(
       }
     }
 
-    if (pendingBreakFitWidth <= fitLimit) {
-      return finishLine(pendingBreakSegmentIndex, 0, pendingBreakPaintWidth)
-    }
-
+    // Do not fall back to the pending soft-hyphen break here; let the
+    // caller's general pending-break check handle it so that a closer
+    // breakAfter opportunity (e.g. a preserved-space) is tried first,
+    // matching the batch walker's check order.
     return null
   }
 


### PR DESCRIPTION
Fixes #121

Two mismatches between `layoutNextLine`/`layoutNextLineRange` (streaming) and `layoutWithLines`/`walkLineRanges` (batch) caused the streaming APIs to produce different line breaks for certain inputs involving mixed scripts, soft hyphens, and non-simple whitespace modes.

## 1. `maybeFinishAtSoftHyphen` premature fallback (pre-wrap + soft-hyphen)

When an overflow occurred at a `breakAfter` segment (preserved-space, tab, etc.) and a soft-hyphen pending break was active, the step function's `maybeFinishAtSoftHyphen` had a fallback path that used the soft-hyphen break even when the segment's `breakableFitAdvances` was `null`. The batch walker's equivalent (`continueSoftHyphenBreakableSegment`) returns `false` in this case, allowing the closer `breakAfter` opportunity to be chosen instead.

**Fix:** Remove the fallback from `maybeFinishAtSoftHyphen` so the general pending-break check handles it, matching the batch walker's check order.

## 2. `normalizeLineStartInChunk` over-strips spaces (chunked path)

`normalizeLineStartInChunk` skipped `space` segments at line starts, but the chunked batch walker (`walkPreparedLinesRaw` non-simple branch) does not strip leading spaces when starting a new line within a chunk. This caused the streaming stepper to skip a leading space that the batch walker kept, producing fewer lines.

**Fix:** Condition the space-skip on `simpleLineWalkFastPath` so only the simple path strips spaces (matching `normalizeSimpleLineStartSegmentIndex` and the simple batch walker).

## Reproduction

Using the reproducer from #121:
```ts
const text = "بام  \u200DB     bا \u00ADb\u060C b\f \u061F\uD83D\uDE80\u061F\u0639 \u0631 \u672C \u061F\na a A\u200B \u8A9E \u8A9E\u200D\u062D"
const prepared = prepareWithSegments(text, font)
const batchLines = layoutWithLines(prepared, 56.57, 20) // 8 lines
const streamLines = collectStreamedLines(prepared, 56.57) // was 7 lines, now 8
```

## Tests

Added 3 regression tests:
- `pre-wrap soft-hyphen does not preempt a closer breakAfter opportunity`
- `layoutNextLine keeps leading space inside a non-simple chunk when the batch walker does`
- `mixed-script Arabic+CJK text keeps streaming aligned with batch layout`

All 87 tests pass (`bun test src/layout.test.ts`).