### PR TITLE
simplify: unify stepRichInlineLine/Stats and remove containsCJKText wrapper

### DIFF
--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -158,10 +158,6 @@ const keepAllGlueChars = new Set([
   '\uFEFF',
 ])
 
-function containsCJKText(text: string): boolean {
-  return isCJK(text)
-}
-
 function endsWithKeepAllGlueText(text: string): boolean {
   const last = getLastCodePoint(text)
   return last !== null && keepAllGlueChars.has(last)
@@ -1211,7 +1207,7 @@ function mergeKeepAllTextSegments(segmentation: MergedSegmentation): MergedSegme
     const start = segmentation.starts[i]!
 
     if (kind === 'text') {
-      const textContainsCJK = containsCJKText(text)
+      const textContainsCJK = isCJK(text)
       const textCanContinue = canContinueKeepAllTextRun(text)
 
       if (pendingTextParts !== null && pendingContainsCJK && pendingCanContinue) {

--- a/src/rich-inline.ts
+++ b/src/rich-inline.ts
@@ -386,139 +386,6 @@ function stepRichInlineLine(
   return lineWidth
 }
 
-function stepRichInlineLineStats(
-  flow: InternalPreparedRichInline,
-  maxWidth: number,
-  cursor: RichInlineCursor,
-): number | null {
-  if (flow.items.length === 0 || cursor.itemIndex >= flow.items.length) return null
-
-  const safeWidth = Math.max(1, maxWidth)
-  let lineWidth = 0
-  let remainingWidth = safeWidth
-  let itemIndex = cursor.itemIndex
-
-  lineLoop:
-  while (itemIndex < flow.items.length) {
-    const item = flow.items[itemIndex]!
-    if (
-      !isLineStartCursor(cursor) &&
-      cursor.segmentIndex === item.endSegmentIndex &&
-      cursor.graphemeIndex === item.endGraphemeIndex
-    ) {
-      itemIndex++
-      cursor.segmentIndex = 0
-      cursor.graphemeIndex = 0
-      continue
-    }
-
-    const gapBefore = lineWidth === 0 ? 0 : item.gapBefore
-    const atItemStart = isLineStartCursor(cursor)
-
-    if (item.break === 'never') {
-      if (!atItemStart) {
-        itemIndex++
-        cursor.segmentIndex = 0
-        cursor.graphemeIndex = 0
-        continue
-      }
-
-      const occupiedWidth = item.naturalWidth + item.extraWidth
-      const totalWidth = gapBefore + occupiedWidth
-      if (lineWidth > 0 && totalWidth > remainingWidth) break lineLoop
-
-      lineWidth += totalWidth
-      remainingWidth = Math.max(0, safeWidth - lineWidth)
-      itemIndex++
-      cursor.segmentIndex = 0
-      cursor.graphemeIndex = 0
-      continue
-    }
-
-    const reservedWidth = gapBefore + item.extraWidth
-    if (lineWidth > 0 && reservedWidth >= remainingWidth) break lineLoop
-
-    if (atItemStart) {
-      const totalWidth = reservedWidth + item.naturalWidth
-      if (totalWidth <= remainingWidth) {
-        lineWidth += totalWidth
-        remainingWidth = Math.max(0, safeWidth - lineWidth)
-        itemIndex++
-        cursor.segmentIndex = 0
-        cursor.graphemeIndex = 0
-        continue
-      }
-    }
-
-    const availableWidth = Math.max(1, remainingWidth - reservedWidth)
-    const lineEnd: LineBreakCursor = {
-      segmentIndex: cursor.segmentIndex,
-      graphemeIndex: cursor.graphemeIndex,
-    }
-    const lineWidthForItem = stepPreparedLineGeometry(item.prepared, lineEnd, availableWidth)
-    if (lineWidthForItem === null) {
-      itemIndex++
-      cursor.segmentIndex = 0
-      cursor.graphemeIndex = 0
-      continue
-    }
-    if (cursor.segmentIndex === lineEnd.segmentIndex && cursor.graphemeIndex === lineEnd.graphemeIndex) {
-      itemIndex++
-      cursor.segmentIndex = 0
-      cursor.graphemeIndex = 0
-      continue
-    }
-
-    if (
-      lineWidth > 0 &&
-      atItemStart &&
-      gapBefore > 0 &&
-      endsInsideFirstSegment(lineEnd.segmentIndex, lineEnd.graphemeIndex)
-    ) {
-      const freshLineEnd: LineBreakCursor = {
-        segmentIndex: 0,
-        graphemeIndex: 0,
-      }
-      const freshLineWidth = stepPreparedLineGeometry(
-        item.prepared,
-        freshLineEnd,
-        Math.max(1, safeWidth - item.extraWidth),
-      )
-      if (
-        freshLineWidth !== null &&
-        (
-          freshLineEnd.segmentIndex > lineEnd.segmentIndex ||
-          (
-            freshLineEnd.segmentIndex === lineEnd.segmentIndex &&
-            freshLineEnd.graphemeIndex > lineEnd.graphemeIndex
-          )
-        )
-      ) {
-        break lineLoop
-      }
-    }
-
-    lineWidth += gapBefore + lineWidthForItem + item.extraWidth
-    remainingWidth = Math.max(0, safeWidth - lineWidth)
-
-    if (lineEnd.segmentIndex === item.endSegmentIndex && lineEnd.graphemeIndex === item.endGraphemeIndex) {
-      itemIndex++
-      cursor.segmentIndex = 0
-      cursor.graphemeIndex = 0
-      continue
-    }
-
-    cursor.segmentIndex = lineEnd.segmentIndex
-    cursor.graphemeIndex = lineEnd.graphemeIndex
-    break
-  }
-
-  if (lineWidth === 0) return null
-
-  cursor.itemIndex = itemIndex
-  return lineWidth
-}
-
 export function layoutNextRichInlineLineRange(
   prepared: PreparedRichInline,
   maxWidth: number,
@@ -625,7 +492,7 @@ export function measureRichInlineStats(
   }
 
   while (true) {
-    const lineWidth = stepRichInlineLineStats(flow, maxWidth, cursor)
+    const lineWidth = stepRichInlineLine(flow, maxWidth, cursor)
     if (lineWidth === null) {
       return {
         lineCount,


### PR DESCRIPTION
Fixes #136

## Changes

Two small simplifications, bundled together since they are each one-liners with no cross-dependencies. Neither changes behavior — all 84 tests pass.

### 1. Remove `stepRichInlineLineStats` (~130 lines deleted)

`stepRichInlineLineStats` was a near-duplicate of `stepRichInlineLine` whose only difference was skipping the optional `collectFragment` callback. Since the callback is already optional (called via `collectFragment?.()`), passing `undefined` achieves the same result.

**Why this matters:** PR #132 had to apply the same overflow guard to both functions in parallel — the exact duplication pattern that makes one-sided patches easy to miss. Unifying the two functions ensures future fixes apply to both the materializing and stats-only paths automatically.

### 2. Inline `containsCJKText()` wrapper (4 lines deleted)

`containsCJKText()` was a single-call-site passthrough to the already-public `isCJK()`. Replaced the call at line 1210 with `isCJK(text)` directly. Similar to the `isCJK` dedup in PR #118.

## Test plan

- [x] `bun test src/layout.test.ts` — 84 tests pass, 0 fail
- [x] No public API changes — only internal function removal
- [x] `measureRichInlineStats` still returns identical results to `walkRichInlineLineRanges` across all existing test cases