### PR TITLE
docs: document breakableFitAdvances cache invariant

### DIFF
--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -200,6 +200,11 @@ export function getSegmentBreakableFitAdvances(
   emojiCorrection: number,
   mode: BreakableFitMode,
 ): number[] | null {
+  // The cached result is mode-agnostic: the current call sites guarantee that
+  // a given segment text always arrives with the same mode, because mode is
+  // determined by isNumericRunSegment(text) (text-deterministic) and the
+  // session-invariant engine profile.  If a future caller breaks this
+  // invariant, the cache will silently return the wrong advances.
   if (metrics.breakableFitAdvances !== undefined) return metrics.breakableFitAdvances
 
   const graphemeSegmenter = getSharedGraphemeSegmenter()


### PR DESCRIPTION
Fixes #137

## Problem

`getSegmentBreakableFitAdvances()` accepts a `mode: BreakableFitMode` parameter but the cache at line 203 returns the stored result without checking whether the mode matches. If a future caller requested the same segment text with a different mode, the cache would silently return the wrong advances.

## Why the cache is safe today

The mode is fully determined by two things that are constant for a given segment text within a session:

1. `isNumericRunSegment(text)` — pure text predicate, always returns the same result for the same string → forces `pair-context`
2. `engineProfile.preferPrefixWidthsForBreakableRuns` — detected once from `navigator.userAgent`, invariant for the session → forces `segment-prefixes`
3. Otherwise → `sum-graphemes`

So the same segment text always arrives with the same mode, and the mode-agnostic cache never returns a mismatched result.

## Change

Added a 5-line comment above the cache check explaining the invariant and the consequence of breaking it. No behavior change, no public API change. All 84 tests pass.

## Test plan

- [x] `bun test src/layout.test.ts` — 84 pass, 0 fail
- [x] Comment-only change — no runtime effect