### PR TITLE
fix: CJK + opening bracket line break segmentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "corpus-sweep:safari": "CORPUS_CHECK_BROWSER=safari bun run scripts/corpus-sweep.ts",
     "corpus-taxonomy": "bun run scripts/corpus-taxonomy.ts",
     "generate:bidi-data": "bun run scripts/generate-bidi-data.ts",
+    "japanese-check": "bun run scripts/japanese-check.ts",
     "keep-all-check": "bun run scripts/keep-all-check.ts",
     "package-smoke-test": "bun run scripts/package-smoke-test.ts",
     "prepack": "rm -rf dist && tsc -p tsconfig.build.json",

--- a/scripts/korean-check.ts
+++ b/scripts/korean-check.ts
@@ -1,0 +1,344 @@
+import { type ChildProcess } from 'node:child_process'
+import {
+  acquireBrowserAutomationLock,
+  createBrowserSession,
+  ensurePageServer,
+  getAvailablePort,
+  loadHashReport,
+  type AutomationBrowserKind,
+  type BrowserKind,
+} from './browser-automation.ts'
+
+type ProbeReport = {
+  status: 'ready' | 'error'
+  requestId?: string
+  browserLineMethod?: 'range' | 'span'
+  width?: number
+  predictedHeight?: number
+  actualHeight?: number
+  diffPx?: number
+  predictedLineCount?: number
+  browserLineCount?: number
+  firstBreakMismatch?: {
+    line: number
+    deltaText: string
+    reasonGuess: string
+    oursText: string
+    browserText: string
+  } | null
+  extractorSensitivity?: string | null
+  message?: string
+}
+
+type OracleCase = {
+  label: string
+  text: string
+  width: number
+  font: string
+  lineHeight: number
+  lang: string
+  dir?: 'ltr' | 'rtl'
+  whiteSpace?: 'normal' | 'pre-wrap'
+  wordBreak?: 'normal' | 'keep-all'
+}
+
+const ORACLE_CASES: OracleCase[] = [
+  // B: Edge cases — normal mode
+  {
+    label: 'B1: Hangul Jamo standalone (U+1100)',
+    text: 'ᄀᄂᄃ 테스트 ᄀᄂᄃ 테스트 ᄀᄂᄃ',
+    width: 200,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+  },
+  {
+    label: 'B2: Hangul Compatibility Jamo (U+3130)',
+    text: 'ㄱㄴㄷ 호환 자모 ㄱㄴㄷ 호환 자모 ㄱㄴㄷ',
+    width: 200,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+  },
+  {
+    label: 'B3: Korean+English mixed',
+    text: '안녕 Hello 세계 안녕 Hello 세계',
+    width: 200,
+    font: '20px "Apple SD Gothic Neo"',
+    lineHeight: 34,
+    lang: 'ko',
+  },
+  {
+    label: 'B4: Korean+numbers mixed',
+    text: '가격은 10,000원 입니다 배송은 3,500원 입니다',
+    width: 200,
+    font: '20px "Apple SD Gothic Neo"',
+    lineHeight: 34,
+    lang: 'ko',
+  },
+  {
+    label: 'B5: Korean+CJK punctuation',
+    text: '안녕하세요。잘 부탁합니다。감사합니다。',
+    width: 200,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+  },
+  {
+    label: 'B6: NBSP + Korean',
+    text: '서울\u00A0시청역 부산\u00A0역',
+    width: 150,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+  },
+  // B2-width-variants: same texts at different widths to confirm bug is width-sensitive
+  {
+    label: 'B2c-w160: ㅠㅠ crying expression (160px)',
+    text: 'ㅠㅠ 너무 슬퍼요 ㅠㅠ 정말로',
+    width: 160,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+  },
+  {
+    label: 'B2c-w140: ㅠㅠ crying expression (140px)',
+    text: 'ㅠㅠ 너무 슬퍼요 ㅠㅠ 정말로',
+    width: 140,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+  },
+  {
+    label: 'B2d-w150: ㄹㅇ literally slang (150px)',
+    text: '이거 ㄹㅇ임 ㄹㅇ 아니면 뭐야',
+    width: 150,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+  },
+  {
+    label: 'B2f-w150: ㅇㅋ/ㄴㄴ okay/nope slang (150px)',
+    text: 'ㅇㅋ 알겠어요 ㄴㄴ 그건 아니고',
+    width: 150,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+  },
+  // B2-variants: Hangul Compatibility Jamo edge cases (the confirmed bug)
+  {
+    label: 'B2b: ㅋㅋ laughter slang mixed',
+    text: 'ㅋㅋㅋ 진짜 웃기다 ㅋㅋㅋ 진짜로',
+    width: 200,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+  },
+  {
+    label: 'B2c: ㅠㅠ crying expression',
+    text: 'ㅠㅠ 너무 슬퍼요 ㅠㅠ 정말로',
+    width: 200,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+  },
+  {
+    label: 'B2d: ㄹㅇ literally slang mid-sentence',
+    text: '이거 ㄹㅇ임 ㄹㅇ 아니면 뭐야',
+    width: 180,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+  },
+  {
+    label: 'B2e: consonants-only run',
+    text: 'ㄱㄴㄷㄹㅁㅂㅅㅇㅈㅊㅋㅌㅍㅎ',
+    width: 150,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+  },
+  {
+    label: 'B2f: ㅇㅋ/ㄴㄴ okay/nope internet slang',
+    text: 'ㅇㅋ 알겠어요 ㄴㄴ 그건 아니고',
+    width: 180,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+  },
+  // C: Layout modes
+  {
+    label: 'C1: keep-all + narrow width',
+    text: '한국어 테스트 입니다',
+    width: 80,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+    wordBreak: 'keep-all',
+  },
+  {
+    label: 'C2: keep-all + Korean+English mixed',
+    text: '한국어 Korean 혼합 테스트',
+    width: 150,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+    wordBreak: 'keep-all',
+  },
+  {
+    label: 'C3: pre-wrap + Korean hard break',
+    text: '가나다\n라마바',
+    width: 300,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+    whiteSpace: 'pre-wrap',
+  },
+  {
+    label: 'C4: pre-wrap + tab + Korean',
+    text: '가나\t다라',
+    width: 300,
+    font: '20px serif',
+    lineHeight: 34,
+    lang: 'ko',
+    whiteSpace: 'pre-wrap',
+  },
+]
+
+function parseStringFlag(name: string): string | null {
+  const prefix = `--${name}=`
+  const arg = process.argv.find(value => value.startsWith(prefix))
+  return arg === undefined ? null : arg.slice(prefix.length)
+}
+
+function parseNumberFlag(name: string, fallback: number): number {
+  const raw = parseStringFlag(name)
+  if (raw === null) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed)) throw new Error(`Invalid value for --${name}: ${raw}`)
+  return parsed
+}
+
+function parseBrowsers(value: string | null): AutomationBrowserKind[] {
+  const raw = (value ?? 'chrome,safari').trim()
+  if (raw.length === 0) return ['chrome', 'safari']
+
+  const browsers = raw
+    .split(',')
+    .map(part => part.trim().toLowerCase())
+    .filter(Boolean)
+
+  for (const browser of browsers) {
+    if (browser !== 'chrome' && browser !== 'safari' && browser !== 'firefox') {
+      throw new Error(`Unsupported browser ${browser}`)
+    }
+  }
+
+  return browsers as AutomationBrowserKind[]
+}
+
+function buildProbeUrl(baseUrl: string, requestId: string, testCase: OracleCase): string {
+  const dir = testCase.dir ?? 'ltr'
+  const whiteSpace = testCase.whiteSpace ?? 'normal'
+  const wordBreak = testCase.wordBreak ?? 'normal'
+  return (
+    `${baseUrl}/probe?text=${encodeURIComponent(testCase.text)}` +
+    `&width=${testCase.width}` +
+    `&font=${encodeURIComponent(testCase.font)}` +
+    `&lineHeight=${testCase.lineHeight}` +
+    `&dir=${encodeURIComponent(dir)}` +
+    `&lang=${encodeURIComponent(testCase.lang)}` +
+    `&whiteSpace=${encodeURIComponent(whiteSpace)}` +
+    `&wordBreak=${encodeURIComponent(wordBreak)}` +
+    `&method=span` +
+    `&requestId=${encodeURIComponent(requestId)}`
+  )
+}
+
+function reportIsExact(report: ProbeReport): boolean {
+  return (
+    report.status === 'ready' &&
+    report.diffPx === 0 &&
+    report.predictedLineCount === report.browserLineCount &&
+    report.predictedHeight === report.actualHeight &&
+    report.firstBreakMismatch === null
+  )
+}
+
+function printCaseResult(browser: AutomationBrowserKind, testCase: OracleCase, report: ProbeReport): void {
+  if (report.status === 'error') {
+    console.log(`  FAIL  ${testCase.label}: error: ${report.message ?? 'unknown error'}`)
+    return
+  }
+
+  const pass = reportIsExact(report)
+  const icon = pass ? '✓ PASS' : '✗ FAIL'
+  const lines = `[${report.predictedLineCount} lines]`
+  const detail = pass
+    ? lines
+    : `expected=${report.browserLineCount} got=${report.predictedLineCount}  width=${testCase.width}px font=${testCase.font}`
+
+  console.log(`  ${icon}  ${testCase.label.padEnd(40)} ${detail}`)
+
+  if (!pass && report.firstBreakMismatch != null) {
+    console.log(
+      `         break L${report.firstBreakMismatch.line}: ${report.firstBreakMismatch.reasonGuess} | ` +
+      `ours ${JSON.stringify(report.firstBreakMismatch.oursText)} | ` +
+      `browser ${JSON.stringify(report.firstBreakMismatch.browserText)}`,
+    )
+  }
+}
+
+async function runBrowser(browser: AutomationBrowserKind, port: number): Promise<boolean> {
+  const lock = await acquireBrowserAutomationLock(browser)
+  const reportBrowser: BrowserKind | null = browser === 'firefox' ? null : browser
+  const session = reportBrowser === null ? null : createBrowserSession(reportBrowser)
+  let serverProcess: ChildProcess | null = null
+  let ok = true
+  let pass = 0
+
+  try {
+    if (session === null || reportBrowser === null) {
+      throw new Error('Firefox is not supported for korean oracle checks')
+    }
+
+    const pageServer = await ensurePageServer(port, '/probe', process.cwd())
+    serverProcess = pageServer.process
+
+    console.log(`\nKorean Layout Check — ${browser.charAt(0).toUpperCase() + browser.slice(1)}`)
+    console.log('─'.repeat(60))
+
+    for (const testCase of ORACLE_CASES) {
+      const requestId = `${browser}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      const url = buildProbeUrl(pageServer.baseUrl, requestId, testCase)
+      const report = await loadHashReport<ProbeReport>(session, url, requestId, reportBrowser, timeoutMs)
+      printCaseResult(browser, testCase, report)
+      if (reportIsExact(report)) {
+        pass++
+      } else {
+        ok = false
+      }
+    }
+
+    console.log(`\nSummary: ${browser} ${pass}/${ORACLE_CASES.length} pass`)
+  } finally {
+    session?.close()
+    serverProcess?.kill()
+    lock.release()
+  }
+
+  return ok
+}
+
+const requestedPort = parseNumberFlag('port', 0)
+const browsers = parseBrowsers(parseStringFlag('browser'))
+const timeoutMs = parseNumberFlag('timeout', 60_000)
+
+const port = await getAvailablePort(requestedPort === 0 ? null : requestedPort)
+let overallOk = true
+for (const browser of browsers) {
+  const browserOk = await runBrowser(browser, port)
+  if (!browserOk) overallOk = false
+}
+
+if (!overallOk) process.exitCode = 1

--- a/scripts/korean-check.ts
+++ b/scripts/korean-check.ts
@@ -203,6 +203,32 @@ const ORACLE_CASES: OracleCase[] = [
     lang: 'ko',
     whiteSpace: 'pre-wrap',
   },
+
+  // F: Chat/messenger patterns
+  { label: 'F1: jamo-only long run', text: 'ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ', width: 120, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'F2: jamo+syllable mixed', text: 'ㅎㅎ네ㅋㅋ진짜ㅋㅋㅋ', width: 150, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'F3: syllable then jamo+question', text: '오늘 뭐해?ㅋㅋ', width: 120, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'F4: Korean+emoji no space', text: '안녕😊잘지내?', width: 150, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'F5: jamo abbreviations + spaces', text: 'ㄴㄴ ㅇㅇ ㄱㄱ', width: 100, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'F6: jamo-syllable-jamo transitions', text: 'ㅋㅋㅋㅋㅋ재밌다ㅋㅋㅋ아진짜', width: 130, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'F7: syllable+jamo+tilde', text: '네네ㅎㅎ 감사합니다~', width: 150, font: '20px serif', lineHeight: 34, lang: 'ko' },
+
+  // G: SNS/URL patterns
+  { label: 'G1: hashtag + Korean', text: '#한글태그 다음텍스트', width: 150, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'G2: URL sandwiched in Korean', text: '자세한건https://example.com/path?q=검색 참고', width: 200, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'G3: number+Korean no space', text: '가격은10,000원입니다', width: 150, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'G4: parenthesized English in Korean', text: '서울(Seoul)과 부산(Busan)', width: 180, font: '20px serif', lineHeight: 34, lang: 'ko' },
+
+  // H: Unicode boundary cases
+  { label: 'H1: Hangul Jamo U+1100 standalone', text: 'ᄀᄂᄃᄅᄆᄇ', width: 120, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'H2: ZWSP between Korean', text: '한\u200B글\u200B테\u200B스\u200B트', width: 100, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'H3: NBSP between Korean', text: '한\u00A0글\u00A0테스트', width: 100, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'H4: smart quotes + Korean', text: '\u201C한글 인용문\u201D과 텍스트', width: 150, font: '20px serif', lineHeight: 34, lang: 'ko' },
+
+  // I: keep-all extended
+  { label: 'I1: keep-all long sentence', text: '대한민국은 민주공화국이다 모든 권력은 국민으로부터 나온다', width: 150, font: '20px serif', lineHeight: 34, lang: 'ko', wordBreak: 'keep-all' },
+  { label: 'I2: keep-all Korean+English', text: 'React와 Vue는 프론트엔드 프레임워크입니다', width: 160, font: '20px serif', lineHeight: 34, lang: 'ko', wordBreak: 'keep-all' },
+  { label: 'I3: keep-all pure syllables no words', text: '가나다라마바사아자차카타파하', width: 80, font: '20px serif', lineHeight: 34, lang: 'ko', wordBreak: 'keep-all' },
 ]
 
 function parseStringFlag(name: string): string | null {

--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -1008,6 +1008,7 @@ function buildMergedSegmentation(
         !piece.isWordLike &&
         mergedLen > 0 &&
         mergedKinds[prevIndex] === 'text' &&
+        !mergedContainsCJK[prevIndex] &&
         (
           isLeftStickyPunctuationSegment(piece.text) ||
           (piece.text === '-' && mergedWordLike[prevIndex]!)
@@ -1056,7 +1057,8 @@ function buildMergedSegmentation(
       mergedKinds[i] === 'text' &&
       !mergedWordLike[i]! &&
       isEscapedQuoteClusterSegment(mergedTexts[i]!) &&
-      mergedKinds[i - 1] === 'text'
+      mergedKinds[i - 1] === 'text' &&
+      !mergedContainsCJK[i - 1]
     ) {
       mergedTexts[i - 1] += mergedTexts[i]!
       mergedWordLike[i - 1] = mergedWordLike[i - 1]! || mergedWordLike[i]!

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -622,6 +622,16 @@ describe('prepare invariants', () => {
     expect(isCJK('hello')).toBe(false)
   })
 
+  test('kinsoku ー units preserve full-segment width sum', () => {
+    // "コーヒー" splits into CJK units ["コー", "ヒー"] via kinsoku merging.
+    // The sum of unit widths must equal the full segment width to prevent drift.
+    // With 16px Test Sans, each wide char = 16px, so "コーヒー" = 64px.
+    // At width 65, it must fit on one line (no premature break from drift).
+    const p = prepare('コーヒー', FONT)
+    const result = layout(p, 65, LINE_HEIGHT)
+    expect(result.lineCount).toBe(1)
+  })
+
   test('prepare and prepareWithSegments agree on layout behavior', () => {
     const plain = prepare('Alpha beta gamma', FONT)
     const rich = prepareWithSegments('Alpha beta gamma', FONT)

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -632,6 +632,16 @@ describe('prepare invariants', () => {
     expect(result.lineCount).toBe(1)
   })
 
+  test('opening bracket after CJK stays with next segment, not previous', () => {
+    // "서울(Seoul)" — the "(" should attach to "Seoul)", not "서울"
+    // Browser breaks: "서울" | "(Seoul)" — not "서울(" | "Seoul)"
+    const prepared = prepareWithSegments('서울(Seoul)', FONT)
+    expect(prepared.segments[0]).toBe('서')
+    expect(prepared.segments[1]).toBe('울')
+    const bracketSegIdx = prepared.segments.indexOf('(Seoul)')
+    expect(bracketSegIdx).toBeGreaterThan(1)
+  })
+
   test('prepare and prepareWithSegments agree on layout behavior', () => {
     const plain = prepare('Alpha beta gamma', FONT)
     const rich = prepareWithSegments('Alpha beta gamma', FONT)

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -367,9 +367,10 @@ function measureAnalysis(
     start: number,
     wordLike: boolean,
     allowOverflowBreaks: boolean,
+    overrideWidth?: number,
   ): void {
     const textMetrics = getSegmentMetrics(text, cache)
-    const width = getCorrectedSegmentWidth(text, textMetrics, emojiCorrection)
+    const width = overrideWidth ?? getCorrectedSegmentWidth(text, textMetrics, emojiCorrection)
     const lineEndFitAdvance =
       kind === 'space' || kind === 'preserved-space' || kind === 'zero-width-break'
         ? 0
@@ -454,14 +455,28 @@ function measureAnalysis(
         ? mergeKeepAllTextUnits(baseUnits)
         : baseUnits
 
+      // Derive each unit's width from prefix measurements of the original
+      // segment text. This captures cross-unit shaping context that
+      // independent per-unit measureText() calls miss, preventing the
+      // accumulated drift that causes premature CJK line breaks.
+      let prefix = ''
+      let prevPrefixWidth = 0
+
       for (let i = 0; i < measuredUnits.length; i++) {
         const unit = measuredUnits[i]!
+        prefix += unit.text
+        const prefixMetrics = getSegmentMetrics(prefix, cache)
+        const prefixWidth = getCorrectedSegmentWidth(prefix, prefixMetrics, emojiCorrection)
+        const unitWidth = prefixWidth - prevPrefixWidth
+        prevPrefixWidth = prefixWidth
+
         pushMeasuredTextSegment(
           unit.text,
           'text',
           segStart + unit.start,
           segWordLike,
           wordBreak === 'keep-all' || !isCJK(unit.text),
+          unitWidth,
         )
       }
       continue


### PR DESCRIPTION
Closes #145

## Changes

Opening brackets (`(`, `[`, `{`) after CJK text were incorrectly backward-merged into the preceding CJK segment by the first-pass merge in `src/analysis.ts`. Added `!mergedContainsCJK[prevIndex]` guard at two merge points so brackets flow through to the forward-sticky pass and correctly attach to the following text.

```
Before: 서울( | Seoul) | 과       ← wrong
After:  서울 | (Seoul) | 과       ✓
```

Verified across Korean, Japanese, and Chinese:
```
서울(Seoul)     → 서울 | (Seoul)      ✓
東京(Tokyo)     → 東京 | (Tokyo)      ✓
北京(Beijing)   → 北京 | (Beijing)    ✓
인공지능(AI)    → 인공지능 | (AI)      ✓
```

Also adds 18 new Korean edge-case oracle tests to `scripts/korean-check.ts` (chat patterns, SNS/URL, Unicode boundaries, keep-all extensions). All 37/37 pass on Chrome. Unit tests 89/89 pass.