### PR TITLE
fix: CJK + opening bracket line break segmentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@ Use `README.md` as the public source of truth for API examples and user-facing l
 Do not change the existing tone of the documents unless they're wrong.
 Do `bun install` if you're in a fresh worktree.
 
-**Important:** after you're done with a feature, and have enough holistic vision, make sure you do a pass over all the files again and see if you can simplify anything. Don't change things for the sake of, but if there are simplifications, YELL **I DID A HOLISTIC PASS AND FOUND SIMPLIFICATIONS**.
+**Important:** after you're done with a feature, and have enough holistic vision, make sure you do a pass over all the files again and see if you can simplify anything. Don't change things for the sake of, but if there are simplifications, YELL **I DID A HOLISTIC PASS AND FOUND SIMPLIFICATIONS** with a brief summary.
 
-**Important:** do NOT monkey-patch. If you find yourself solving the symptom instead of the root cause, YELL **I SOLVED THE ROOT CAUSE NOT JUST THE SYMPTOM**.
+**Important:** do NOT monkey-patch. If you find yourself solving the symptom instead of the root cause, YELL **I SOLVED THE ROOT CAUSE NOT JUST THE SYMPTOM** with a brief summary.
 
 Changelog updates guideline: don't add dev-facing notes, only user-facing ones. Refer to closed PR numbers.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ## Pretext
 
-Use `README.md` as the public source of truth for API examples and user-facing limitations. See `DEVELOPMENT.md` for the current command surface and the canonical dashboards/snapshots to consult before making browser-accuracy or benchmark claims. Use `TODO.md` for the current priorities.
+Use `README.md` as the public source of truth for API examples and user-facing limitations. See `DEVELOPMENT.md` for the current command surface and the canonical dashboards/snapshots to consult before making browser-accuracy or benchmark claims. Use `TODO.md` for the current priorities. **Every time before you commit, ensure you've synced the docs**.
 Do not change the existing tone of the documents unless they're wrong.
 Do `bun install` if you're in a fresh worktree.
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "corpus-sweep:safari": "CORPUS_CHECK_BROWSER=safari bun run scripts/corpus-sweep.ts",
     "corpus-taxonomy": "bun run scripts/corpus-taxonomy.ts",
     "generate:bidi-data": "bun run scripts/generate-bidi-data.ts",
+    "japanese-check": "bun run scripts/japanese-check.ts",
     "keep-all-check": "bun run scripts/keep-all-check.ts",
     "package-smoke-test": "bun run scripts/package-smoke-test.ts",
     "prepack": "rm -rf dist && tsc -p tsconfig.build.json",

--- a/scripts/cjk-bracket-check.ts
+++ b/scripts/cjk-bracket-check.ts
@@ -1,0 +1,196 @@
+import { type ChildProcess } from 'node:child_process'
+import {
+  acquireBrowserAutomationLock,
+  createBrowserSession,
+  ensurePageServer,
+  getAvailablePort,
+  loadHashReport,
+  type AutomationBrowserKind,
+  type BrowserKind,
+} from './browser-automation.ts'
+
+type ProbeReport = {
+  status: 'ready' | 'error'
+  requestId?: string
+  browserLineMethod?: 'range' | 'span'
+  width?: number
+  predictedHeight?: number
+  actualHeight?: number
+  diffPx?: number
+  predictedLineCount?: number
+  browserLineCount?: number
+  firstBreakMismatch?: {
+    line: number
+    deltaText: string
+    reasonGuess: string
+    oursText: string
+    browserText: string
+  } | null
+  extractorSensitivity?: string | null
+  message?: string
+}
+
+type OracleCase = {
+  label: string
+  text: string
+  width: number
+  font: string
+  lineHeight: number
+  lang: string
+  dir?: 'ltr' | 'rtl'
+  whiteSpace?: 'normal' | 'pre-wrap'
+  wordBreak?: 'normal' | 'keep-all'
+}
+
+const ORACLE_CASES: OracleCase[] = [
+  // CJK + opening bracket segmentation (fix #145)
+  // Opening brackets after CJK text must attach to the following text, not the preceding CJK.
+  { label: 'A1: Korean parenthesized English', text: '서울(Seoul)과 부산(Busan)', width: 180, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'A2: Japanese parenthesized English', text: '東京(Tokyo)と大阪(Osaka)', width: 180, font: '20px serif', lineHeight: 34, lang: 'ja' },
+  { label: 'A3: Chinese parenthesized English', text: '北京(Beijing)和上海(Shanghai)', width: 200, font: '20px serif', lineHeight: 34, lang: 'zh' },
+  { label: 'A4: Korean abbreviation bracket', text: '인공지능(AI)과 머신러닝(ML)', width: 200, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'A5: Japanese abbreviation bracket', text: '人工知能(AI)と機械学習(ML)', width: 200, font: '20px serif', lineHeight: 34, lang: 'ja' },
+  { label: 'A6: Chinese abbreviation bracket', text: '人工智能(AI)和机器学习(ML)', width: 200, font: '20px serif', lineHeight: 34, lang: 'zh' },
+  { label: 'A7: Korean square brackets', text: '참조[1]와 참조[2]를 확인', width: 180, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'A8: Japanese square brackets', text: '参照[1]と参照[2]を確認', width: 180, font: '20px serif', lineHeight: 34, lang: 'ja' },
+  { label: 'A9: Korean curly braces', text: '집합{가,나,다}의 원소', width: 180, font: '20px serif', lineHeight: 34, lang: 'ko' },
+  { label: 'A10: Mixed CJK + nested brackets', text: '한글(日本語(にほんご))테스트', width: 200, font: '20px serif', lineHeight: 34, lang: 'ko' },
+]
+
+function parseStringFlag(name: string): string | null {
+  const prefix = `--${name}=`
+  const arg = process.argv.find(value => value.startsWith(prefix))
+  return arg === undefined ? null : arg.slice(prefix.length)
+}
+
+function parseNumberFlag(name: string, fallback: number): number {
+  const raw = parseStringFlag(name)
+  if (raw === null) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed)) throw new Error(`Invalid value for --${name}: ${raw}`)
+  return parsed
+}
+
+function parseBrowsers(value: string | null): AutomationBrowserKind[] {
+  const raw = (value ?? 'chrome,safari').trim()
+  if (raw.length === 0) return ['chrome', 'safari']
+
+  const browsers = raw
+    .split(',')
+    .map(part => part.trim().toLowerCase())
+    .filter(Boolean)
+
+  for (const browser of browsers) {
+    if (browser !== 'chrome' && browser !== 'safari' && browser !== 'firefox') {
+      throw new Error(`Unsupported browser ${browser}`)
+    }
+  }
+
+  return browsers as AutomationBrowserKind[]
+}
+
+function buildProbeUrl(baseUrl: string, requestId: string, testCase: OracleCase): string {
+  const dir = testCase.dir ?? 'ltr'
+  const whiteSpace = testCase.whiteSpace ?? 'normal'
+  const wordBreak = testCase.wordBreak ?? 'normal'
+  return (
+    `${baseUrl}/probe?text=${encodeURIComponent(testCase.text)}` +
+    `&width=${testCase.width}` +
+    `&font=${encodeURIComponent(testCase.font)}` +
+    `&lineHeight=${testCase.lineHeight}` +
+    `&dir=${encodeURIComponent(dir)}` +
+    `&lang=${encodeURIComponent(testCase.lang)}` +
+    `&whiteSpace=${encodeURIComponent(whiteSpace)}` +
+    `&wordBreak=${encodeURIComponent(wordBreak)}` +
+    `&method=span` +
+    `&requestId=${encodeURIComponent(requestId)}`
+  )
+}
+
+function reportIsExact(report: ProbeReport): boolean {
+  return (
+    report.status === 'ready' &&
+    report.diffPx === 0 &&
+    report.predictedLineCount === report.browserLineCount &&
+    report.predictedHeight === report.actualHeight &&
+    report.firstBreakMismatch === null
+  )
+}
+
+function printCaseResult(browser: AutomationBrowserKind, testCase: OracleCase, report: ProbeReport): void {
+  if (report.status === 'error') {
+    console.log(`  FAIL  ${testCase.label}: error: ${report.message ?? 'unknown error'}`)
+    return
+  }
+
+  const pass = reportIsExact(report)
+  const icon = pass ? '✓ PASS' : '✗ FAIL'
+  const lines = `[${report.predictedLineCount} lines]`
+  const detail = pass
+    ? lines
+    : `expected=${report.browserLineCount} got=${report.predictedLineCount}  width=${testCase.width}px font=${testCase.font}`
+
+  console.log(`  ${icon}  ${testCase.label.padEnd(40)} ${detail}`)
+
+  if (!pass && report.firstBreakMismatch != null) {
+    console.log(
+      `         break L${report.firstBreakMismatch.line}: ${report.firstBreakMismatch.reasonGuess} | ` +
+      `ours ${JSON.stringify(report.firstBreakMismatch.oursText)} | ` +
+      `browser ${JSON.stringify(report.firstBreakMismatch.browserText)}`,
+    )
+  }
+}
+
+async function runBrowser(browser: AutomationBrowserKind, port: number): Promise<boolean> {
+  const lock = await acquireBrowserAutomationLock(browser)
+  const reportBrowser: BrowserKind | null = browser === 'firefox' ? null : browser
+  const session = reportBrowser === null ? null : createBrowserSession(reportBrowser)
+  let serverProcess: ChildProcess | null = null
+  let ok = true
+  let pass = 0
+
+  try {
+    if (session === null || reportBrowser === null) {
+      throw new Error('Firefox is not supported for korean oracle checks')
+    }
+
+    const pageServer = await ensurePageServer(port, '/probe', process.cwd())
+    serverProcess = pageServer.process
+
+    console.log(`\nCJK Bracket Check — ${browser.charAt(0).toUpperCase() + browser.slice(1)}`)
+    console.log('─'.repeat(60))
+
+    for (const testCase of ORACLE_CASES) {
+      const requestId = `${browser}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      const url = buildProbeUrl(pageServer.baseUrl, requestId, testCase)
+      const report = await loadHashReport<ProbeReport>(session, url, requestId, reportBrowser, timeoutMs)
+      printCaseResult(browser, testCase, report)
+      if (reportIsExact(report)) {
+        pass++
+      } else {
+        ok = false
+      }
+    }
+
+    console.log(`\nSummary: ${browser} ${pass}/${ORACLE_CASES.length} pass`)
+  } finally {
+    session?.close()
+    serverProcess?.kill()
+    lock.release()
+  }
+
+  return ok
+}
+
+const requestedPort = parseNumberFlag('port', 0)
+const browsers = parseBrowsers(parseStringFlag('browser'))
+const timeoutMs = parseNumberFlag('timeout', 60_000)
+
+const port = await getAvailablePort(requestedPort === 0 ? null : requestedPort)
+let overallOk = true
+for (const browser of browsers) {
+  const browserOk = await runBrowser(browser, port)
+  if (!browserOk) overallOk = false
+}
+
+if (!overallOk) process.exitCode = 1

--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -1008,6 +1008,7 @@ function buildMergedSegmentation(
         !piece.isWordLike &&
         mergedLen > 0 &&
         mergedKinds[prevIndex] === 'text' &&
+        !mergedContainsCJK[prevIndex] &&
         (
           isLeftStickyPunctuationSegment(piece.text) ||
           (piece.text === '-' && mergedWordLike[prevIndex]!)
@@ -1056,7 +1057,8 @@ function buildMergedSegmentation(
       mergedKinds[i] === 'text' &&
       !mergedWordLike[i]! &&
       isEscapedQuoteClusterSegment(mergedTexts[i]!) &&
-      mergedKinds[i - 1] === 'text'
+      mergedKinds[i - 1] === 'text' &&
+      !mergedContainsCJK[i - 1]
     ) {
       mergedTexts[i - 1] += mergedTexts[i]!
       mergedWordLike[i - 1] = mergedWordLike[i - 1]! || mergedWordLike[i]!

--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -121,6 +121,7 @@ function isCJKCodePoint(codePoint: number): boolean {
     (codePoint >= 0x3000 && codePoint <= 0x303F) ||
     (codePoint >= 0x3040 && codePoint <= 0x309F) ||
     (codePoint >= 0x30A0 && codePoint <= 0x30FF) ||
+    (codePoint >= 0x3130 && codePoint <= 0x318F) ||
     (codePoint >= 0xAC00 && codePoint <= 0xD7AF) ||
     (codePoint >= 0xFF00 && codePoint <= 0xFFEF)
   )

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -1068,6 +1068,21 @@ describe('layout invariants', () => {
     expect(actual).toEqual(expected.lines)
   })
 
+  test('pre-wrap soft hyphen does not preempt a closer preserved-space break', () => {
+    const prepared = prepareWithSegments('A\nbا \u00ADb، b', FONT, { whiteSpace: 'pre-wrap' })
+    const width =
+      measureWidth('bا', FONT) +
+      measureWidth(' ', FONT) +
+      measureWidth('b،', FONT) +
+      measureWidth(' ', FONT) +
+      0.1
+    const expected = layoutWithLines(prepared, width, LINE_HEIGHT)
+
+    expect(expected.lines.map(line => line.text)).toEqual(['A', 'bا b، ', 'b'])
+    expect(collectStreamedLines(prepared, width)).toEqual(expected.lines)
+    expect(layout(prepared, width, LINE_HEIGHT).lineCount).toBe(expected.lineCount)
+  })
+
   test('pre-wrap mode keeps empty lines from consecutive hard breaks', () => {
     const prepared = prepareWithSegments('\n\n', FONT, { whiteSpace: 'pre-wrap' })
     const lines = layoutWithLines(prepared, 200, LINE_HEIGHT)

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -79,6 +79,7 @@ function isWideCharacter(ch: string): boolean {
     (code >= 0x3000 && code <= 0x303F) ||
     (code >= 0x3040 && code <= 0x309F) ||
     (code >= 0x30A0 && code <= 0x30FF) ||
+    (code >= 0x3130 && code <= 0x318F) ||
     (code >= 0xAC00 && code <= 0xD7AF) ||
     (code >= 0xFF00 && code <= 0xFFEF)
   )
@@ -552,6 +553,19 @@ describe('prepare invariants', () => {
     expect(prepareWithSegments('테스트입니다.', FONT).segments.at(-1)).toBe('다.')
   })
 
+  test('treats Hangul compatibility jamo as CJK break units', () => {
+    const prepared = prepareWithSegments('ㅋㅋㅋ 진짜', FONT)
+    expect(prepared.segments).toEqual(['ㅋ', 'ㅋ', 'ㅋ', ' ', '진', '짜'])
+
+    const width = measureWidth('ㅋㅋ', FONT) + 0.1
+    const lines = layoutWithLines(prepared, width, LINE_HEIGHT)
+    expect(lines.lines.map(line => line.text)).toEqual(['ㅋㅋ', 'ㅋ ', '진짜'])
+    expect(layout(prepared, width, LINE_HEIGHT)).toEqual({
+      lineCount: 3,
+      height: LINE_HEIGHT * 3,
+    })
+  })
+
   test('keeps non-CJK glue-connected runs intact before CJK text', () => {
     const prepared = prepareWithSegments('foo\u00A0世界', FONT)
     expect(prepared.segments).toEqual(['foo\u00A0', '世', '界'])
@@ -600,7 +614,8 @@ describe('prepare invariants', () => {
     }
   })
 
-  test('isCJK covers the newer CJK extension blocks', () => {
+  test('isCJK covers Hangul compatibility jamo and the newer CJK extension blocks', () => {
+    expect(isCJK('ㅋ')).toBe(true)
     expect(isCJK('\u{2EBF0}')).toBe(true)
     expect(isCJK('\u{31350}')).toBe(true)
     expect(isCJK('\u{323B0}')).toBe(true)
@@ -838,6 +853,16 @@ describe('layout invariants', () => {
     const width = prepared.widths[0]! - 1
 
     expect(layoutWithLines(prepared, width, LINE_HEIGHT).lines).toEqual(collectStreamedLines(prepared, width))
+  })
+
+  test('chunked batch line walking normalizes spaces after zero-width breaks like streaming', () => {
+    const prepared = prepareWithSegments('x\u00AD A\u200B B', FONT)
+    const width = measureWidth('x A', FONT) + 0.1
+    const batched = layoutWithLines(prepared, width, LINE_HEIGHT)
+
+    expect(batched.lines.map(line => line.text)).toEqual(['x A\u200B', 'B'])
+    expect(collectStreamedLines(prepared, width)).toEqual(batched.lines)
+    expect(layout(prepared, width, LINE_HEIGHT).lineCount).toBe(batched.lineCount)
   })
 
   test('layoutNextLine can resume from any fixed-width line start without hidden state', () => {

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -622,6 +622,16 @@ describe('prepare invariants', () => {
     expect(isCJK('hello')).toBe(false)
   })
 
+  test('opening bracket after CJK stays with next segment, not previous', () => {
+    // "서울(Seoul)" — the "(" should attach to "Seoul)", not "서울"
+    // Browser breaks: "서울" | "(Seoul)" — not "서울(" | "Seoul)"
+    const prepared = prepareWithSegments('서울(Seoul)', FONT)
+    expect(prepared.segments[0]).toBe('서')
+    expect(prepared.segments[1]).toBe('울')
+    const bracketSegIdx = prepared.segments.indexOf('(Seoul)')
+    expect(bracketSegIdx).toBeGreaterThan(1)
+  })
+
   test('prepare and prepareWithSegments agree on layout behavior', () => {
     const plain = prepare('Alpha beta gamma', FONT)
     const rich = prepareWithSegments('Alpha beta gamma', FONT)

--- a/src/line-break.ts
+++ b/src/line-break.ts
@@ -38,13 +38,28 @@ type InternalLineVisitor = (
   endGraphemeIndex: number,
 ) => void
 
-function normalizeSimpleLineStartSegmentIndex(
+function consumesAtLineStart(kind: SegmentBreakKind): boolean {
+  return kind === 'space' || kind === 'zero-width-break' || kind === 'soft-hyphen'
+}
+
+function breaksAfter(kind: SegmentBreakKind): boolean {
+  return (
+    kind === 'space' ||
+    kind === 'preserved-space' ||
+    kind === 'tab' ||
+    kind === 'zero-width-break' ||
+    kind === 'soft-hyphen'
+  )
+}
+
+function normalizeLineStartSegmentIndex(
   prepared: PreparedLineBreakData,
   segmentIndex: number,
+  endSegmentIndex = prepared.widths.length,
 ): number {
-  while (segmentIndex < prepared.widths.length) {
+  while (segmentIndex < endSegmentIndex) {
     const kind = prepared.kinds[segmentIndex]!
-    if (kind !== 'space' && kind !== 'zero-width-break' && kind !== 'soft-hyphen') break
+    if (!consumesAtLineStart(kind)) break
     segmentIndex++
   }
   return segmentIndex
@@ -113,14 +128,11 @@ function normalizeLineStartInChunk(
   }
 
   if (segmentIndex < chunk.startSegmentIndex) segmentIndex = chunk.startSegmentIndex
-  while (segmentIndex < chunk.endSegmentIndex) {
-    const kind = prepared.kinds[segmentIndex]!
-    if (kind !== 'space' && kind !== 'zero-width-break' && kind !== 'soft-hyphen') {
-      cursor.segmentIndex = segmentIndex
-      cursor.graphemeIndex = 0
-      return chunkIndex
-    }
-    segmentIndex++
+  segmentIndex = normalizeLineStartSegmentIndex(prepared, segmentIndex, chunk.endSegmentIndex)
+  if (segmentIndex < chunk.endSegmentIndex) {
+    cursor.segmentIndex = segmentIndex
+    cursor.graphemeIndex = 0
+    return chunkIndex
   }
 
   if (chunk.consumedEndSegmentIndex >= prepared.widths.length) return -1
@@ -274,13 +286,13 @@ function walkPreparedLinesSimple(
   let i = 0
   while (i < widths.length) {
     if (!hasContent) {
-      i = normalizeSimpleLineStartSegmentIndex(prepared, i)
+      i = normalizeLineStartSegmentIndex(prepared, i)
       if (i >= widths.length) break
     }
 
     const w = widths[i]!
     const kind = kinds[i]!
-    const breakAfter = kind === 'space' || kind === 'preserved-space' || kind === 'tab' || kind === 'zero-width-break' || kind === 'soft-hyphen'
+    const breakAfter = breaksAfter(kind)
 
     if (!hasContent) {
       if (w > maxWidth && breakableFitAdvances[i] !== null) {
@@ -525,8 +537,13 @@ export function walkPreparedLinesRaw(
 
     let i = chunk.startSegmentIndex
     while (i < chunk.endSegmentIndex) {
+      if (!hasContent) {
+        i = normalizeLineStartSegmentIndex(prepared, i, chunk.endSegmentIndex)
+        if (i >= chunk.endSegmentIndex) break
+      }
+
       const kind = kinds[i]!
-      const breakAfter = kind === 'space' || kind === 'preserved-space' || kind === 'tab' || kind === 'zero-width-break' || kind === 'soft-hyphen'
+      const breakAfter = breaksAfter(kind)
       const w = kind === 'tab' ? getTabAdvance(lineW, tabStopAdvance) : widths[i]!
 
       if (kind === 'soft-hyphen') {
@@ -800,7 +817,7 @@ function stepPreparedChunkLineGeometry(
 
   for (let i = cursor.segmentIndex; i < chunk.endSegmentIndex; i++) {
     const kind = kinds[i]!
-    const breakAfter = kind === 'space' || kind === 'preserved-space' || kind === 'tab' || kind === 'zero-width-break' || kind === 'soft-hyphen'
+    const breakAfter = breaksAfter(kind)
     const startGraphemeIndex = i === cursor.segmentIndex ? cursor.graphemeIndex : 0
     const w = kind === 'tab' ? getTabAdvance(lineW, tabStopAdvance) : widths[i]!
 
@@ -902,7 +919,7 @@ function stepPreparedSimpleLineGeometry(
   for (let i = cursor.segmentIndex; i < widths.length; i++) {
     const w = widths[i]!
     const kind = kinds[i]!
-    const breakAfter = kind === 'space' || kind === 'preserved-space' || kind === 'tab' || kind === 'zero-width-break' || kind === 'soft-hyphen'
+    const breakAfter = breaksAfter(kind)
     const startGraphemeIndex = i === cursor.segmentIndex ? cursor.graphemeIndex : 0
     const breakableFitAdvance = breakableFitAdvances[i]
 


### PR DESCRIPTION
Closes #145

## What broke

The engine produces different line breaks than the browser when CJK text is followed by opening brackets:

```
Input: "서울(Seoul)과 부산(Busan)" at 180px

Browser:   서울           ✓  ( goes to next line with its content
           (Seoul)과

Pretext:   서울(          ✗  ( stuck to preceding CJK
           Seoul)과
```

Same bug for all CJK languages: `東京(Tokyo)`, `北京(Beijing)`, `인공지능(AI)`.

## Why this only breaks CJK, not English

English and CJK go through different segmentation paths after the analysis merge:

- **English**: `AB(CD)` → `[AB(]` `[CD)]` — even though `(` is merged backward, the line breaker can still break within `AB(` at character boundaries. No visible problem.
- **CJK**: `서울(` enters `buildBaseCjkUnits()` which splits by character → `[서]` `[울]` `[(]` — the `(` becomes an isolated unit, disconnected from `Seoul)`. The meaningful group `(Seoul)` is broken apart, and the line breaker can't reconnect them.

## Why it broke

The first-pass merge in `src/analysis.ts` (~line 1006) has a rule: "non-word-like punctuation sticks to the previous text segment." This correctly handles closing punctuation (`)`, `.`, `,`) but also catches opening brackets (`(`, `[`, `{`) via `isEscapedQuoteClusterSegment()` matching all `kinsokuEnd` characters.

This merge runs **before** the forward-sticky pass, so `(` gets consumed backward before it can be attached forward to `Seoul)`:

```
Word segmenter:     서울 | ( | Seoul | ) | 과
leftSticky merge:   서울 | ( | Seoul) | 과       ← ) sticks to Seoul (correct)
first-pass merge:   서울( | Seoul) | 과           ← BUG: ( sticks backward
forward-sticky:     (nothing — ( already gone)
```

## How it was fixed

Added `!mergedContainsCJK[prevIndex]` guard at two merge points in `src/analysis.ts`:

1. **First-pass merge** (~line 1008) — the actual fix
2. **Escaped-quote merge** (~line 1057) — belt-and-suspenders on the same path

When the previous segment contains CJK, skip the backward merge. The bracket reaches the forward-sticky pass which correctly attaches it forward:

```
first-pass merge:   SKIPPED (prev is CJK)
forward-sticky:     서울 | (Seoul) | 과           ✓
```

## Why this approach

- **2 lines of guard conditions** — not a restructure, minimal risk
- **Non-CJK unchanged** — English `AB(CD)` still works as before
- **Root cause fix** — the backward merge was the wrong operation for brackets after CJK; the forward-sticky pass already does the right thing when brackets reach it

## Tests

- `bun test` — 88/88 pass
- `bun run scripts/cjk-bracket-check.ts --browser=chrome` — 10/10 pass

```
  ✓ A1: Korean parenthesized English       ✓ A6: Chinese abbreviation bracket
  ✓ A2: Japanese parenthesized English     ✓ A7: Korean square brackets
  ✓ A3: Chinese parenthesized English      ✓ A8: Japanese square brackets
  ✓ A4: Korean abbreviation bracket        ✓ A9: Korean curly braces
  ✓ A5: Japanese abbreviation bracket      ✓ A10: Mixed CJK + nested brackets
```