### PR TITLE
unicode-line-breaks-18218157775797050513

### DIFF
--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -38,8 +38,8 @@ export type AnalysisProfile = {
   carryCJKAfterClosingQuote: boolean
 }
 
-const collapsibleWhitespaceRunRe = /[ \t\n\r\f]+/g
-const needsWhitespaceNormalizationRe = /[\t\n\r\f]| {2,}|^ | $/
+const collapsibleWhitespaceRunRe = /[ \t\n\r\f\v\u0085\u2028\u2029]+/g
+const needsWhitespaceNormalizationRe = /[\t\n\r\f\v\u0085\u2028\u2029]| {2,}|^ | $/
 
 type WhiteSpaceProfile = {
   mode: WhiteSpaceMode
@@ -68,10 +68,10 @@ export function normalizeWhitespaceNormal(text: string): string {
 }
 
 function normalizeWhitespacePreWrap(text: string): string {
-  if (!/[\r\f]/.test(text)) return text
+  if (!/[\r\f\v\u0085\u2028\u2029]/.test(text)) return text
   return text
     .replace(/\r\n/g, '\n')
-    .replace(/[\r\f]/g, '\n')
+    .replace(/[\r\f\v\u0085\u2028\u2029]/g, '\n')
 }
 
 let sharedWordSegmenter: Intl.Segmenter | null = null
@@ -416,7 +416,12 @@ function classifySegmentBreakChar(ch: string, whiteSpaceProfile: WhiteSpaceProfi
   if (whiteSpaceProfile.preserveOrdinarySpaces || whiteSpaceProfile.preserveHardBreaks) {
     if (ch === ' ') return 'preserved-space'
     if (ch === '\t') return 'tab'
-    if (whiteSpaceProfile.preserveHardBreaks && ch === '\n') return 'hard-break'
+    if (
+      whiteSpaceProfile.preserveHardBreaks &&
+      (ch === '\n' || ch === '\v' || ch === '\u0085' || ch === '\u2028' || ch === '\u2029')
+    ) {
+      return 'hard-break'
+    }
   }
   if (ch === ' ') return 'space'
   if (ch === '\u00A0' || ch === '\u202F' || ch === '\u2060' || ch === '\uFEFF') {
@@ -428,7 +433,7 @@ function classifySegmentBreakChar(ch: string, whiteSpaceProfile: WhiteSpaceProfi
 }
 
 // All characters that classifySegmentBreakChar maps to a non-'text' kind.
-const breakCharRe = /[\x20\t\n\xA0\xAD\u200B\u202F\u2060\uFEFF]/
+const breakCharRe = /[\x20\t\n\v\xA0\xAD\u0085\u200B\u2028\u2029\u202F\u2060\uFEFF]/
 
 function joinTextParts(parts: string[]): string {
   return parts.length === 1 ? parts[0]! : parts.join('')

--- a/src/compliance.test.ts
+++ b/src/compliance.test.ts
@@ -1,0 +1,71 @@
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+
+const FONT = '16px Test Sans'
+const LINE_HEIGHT = 19
+
+type LayoutModule = typeof import('./layout.ts')
+
+let prepare: LayoutModule['prepare']
+let prepareWithSegments: LayoutModule['prepareWithSegments']
+let layout: LayoutModule['layout']
+let layoutWithLines: LayoutModule['layoutWithLines']
+let clearCache: LayoutModule['clearCache']
+let setLocale: LayoutModule['setLocale']
+
+class TestCanvasRenderingContext2D {
+  font = ''
+  measureText(text: string): { width: number } {
+    return { width: text.length * 10 }
+  }
+}
+
+class TestOffscreenCanvas {
+  constructor(_width: number, _height: number) {}
+  getContext(_kind: string): TestCanvasRenderingContext2D {
+    return new TestCanvasRenderingContext2D()
+  }
+}
+
+beforeAll(async () => {
+  Reflect.set(globalThis, 'OffscreenCanvas', TestOffscreenCanvas)
+  const mod = await import('./layout.ts')
+  ;({
+    prepare,
+    prepareWithSegments,
+    layout,
+    layoutWithLines,
+    clearCache,
+    setLocale,
+  } = mod)
+})
+
+beforeEach(() => {
+  setLocale(undefined)
+  clearCache()
+})
+
+describe('Unicode line break compliance', () => {
+  const lineBreakers = [
+    { name: 'Vertical Tab', char: '\v' },
+    { name: 'Next Line', char: '\u0085' },
+    { name: 'Line Separator', char: '\u2028' },
+    { name: 'Paragraph Separator', char: '\u2029' },
+  ]
+
+  for (const { name, char } of lineBreakers) {
+    test(`normal mode collapses ${name}`, () => {
+      const prepared = prepare(`a${char}b`, FONT)
+      const result = layout(prepared, 200, LINE_HEIGHT)
+      expect(result.lineCount).toBe(1)
+    })
+
+    test(`pre-wrap mode treats ${name} as hard-break`, () => {
+      const prepared = prepare(`a${char}b`, FONT, { whiteSpace: 'pre-wrap' })
+      const result = layout(prepared, 200, LINE_HEIGHT)
+      expect(result.lineCount).toBe(2)
+
+      const rich = layoutWithLines(prepareWithSegments(`a${char}b`, FONT, { whiteSpace: 'pre-wrap' }), 200, LINE_HEIGHT)
+      expect(rich.lines.map(l => l.text)).toEqual(['a', 'b'])
+    })
+  }
+})


### PR DESCRIPTION
This PR improves Pretext's compliance with Unicode line breaking standards by adding support for Vertical Tab, Next Line, Line Separator, and Paragraph Separator. These characters are now correctly handled in both `normal` and `pre-wrap` whitespace modes.

Changes:
- Updated `collapsibleWhitespaceRunRe` and `needsWhitespaceNormalizationRe` to include the new characters.
- Modified `normalizeWhitespacePreWrap` to map them to `\n` for consistent hard-break handling.
- Enhanced `classifySegmentBreakChar` and `breakCharRe` to recognize them as segment boundaries.
- Added a new test file `src/compliance.test.ts` with TDD-style tests for these cases.
- Verified that all existing tests in `src/layout.test.ts` continue to pass.
