### PR TITLE
feat: letterSpacing option via Canvas native API

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ Pretext doesn't try to be a full font rendering engine (yet?). It currently targ
   const prepared = prepare(text, font, { letterSpacing: '2px' })
   ```
 
+  The value is a CSS `<length>` string (e.g. `'1px'`, `'0.05em'`). Invalid values are silently ignored by the Canvas API, falling back to no spacing.
+
   Other CSS text features outside the canvas `font` shorthand, such as `font-optical-sizing`, `font-feature-settings`, and standalone `font-variation-settings`, are not modeled separately. These properties are not in the Canvas 2D spec. Variable-font axes only help when the active axis is reflected in the canvas font string, for example via weight.
 
 ## Develop

--- a/README.md
+++ b/README.md
@@ -235,7 +235,13 @@ Pretext doesn't try to be a full font rendering engine (yet?). It currently targ
 - `{ wordBreak: 'keep-all' }` is supported too. It behaves like you'd expect for CJK/Hangul text, while keeping the same `overflow-wrap: break-word` fallback for overlong runs.
 - `system-ui` is unsafe for `layout()` accuracy on macOS. Use a named font.
 - Runtime requires `Intl.Segmenter` and Canvas 2D text measurement. Browsers or runtimes without `Intl.Segmenter` are currently unsupported.
-- CSS text features outside the canvas `font` shorthand, such as `letter-spacing`, `font-optical-sizing`, `font-feature-settings`, and standalone `font-variation-settings`, are not modeled separately. Variable-font axes only help when the active axis is reflected in the canvas font string, for example via weight.
+- `letter-spacing` is supported via the `letterSpacing` option in `prepare()`:
+
+  ```ts
+  const prepared = prepare(text, font, { letterSpacing: '2px' })
+  ```
+
+  Other CSS text features outside the canvas `font` shorthand, such as `font-optical-sizing`, `font-feature-settings`, and standalone `font-variation-settings`, are not modeled separately. These properties are not in the Canvas 2D spec. Variable-font axes only help when the active axis is reflected in the canvas font string, for example via weight.
 
 ## Develop
 

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -1303,4 +1303,15 @@ describe('layout invariants', () => {
     for (let i = 0; i < spaced.widths.length; i++) spacedTotal += spaced.widths[i]!
     expect(spacedTotal).toBeGreaterThan(baseTotal)
   })
+
+  test('letterSpacing applies to emoji text', () => {
+    const base = prepareWithSegments('Hello 😀🎉 World', FONT)
+    const spaced = prepareWithSegments('Hello 😀🎉 World', FONT, { letterSpacing: '2px' })
+
+    let baseTotal = 0
+    let spacedTotal = 0
+    for (let i = 0; i < base.widths.length; i++) baseTotal += base.widths[i]!
+    for (let i = 0; i < spaced.widths.length; i++) spacedTotal += spaced.widths[i]!
+    expect(spacedTotal).toBeGreaterThan(baseTotal)
+  })
 })

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -246,9 +246,15 @@ function getNonSpaceSegmentLevels(
 
 class TestCanvasRenderingContext2D {
   font = ''
+  letterSpacing = '0px'
 
   measureText(text: string): { width: number } {
-    return { width: measureWidth(text, this.font) }
+    const baseWidth = measureWidth(text, this.font)
+    const spacing = parseFloat(this.letterSpacing) || 0
+    if (spacing === 0) return { width: baseWidth }
+    let graphemeCount = 0
+    for (const _ of graphemeSegmenter.segment(text)) graphemeCount++
+    return { width: baseWidth + graphemeCount * spacing }
   }
 }
 
@@ -1251,5 +1257,50 @@ describe('layout invariants', () => {
         expect(counted).toBe(walked)
       }
     }
+  })
+
+  test('letterSpacing increases total prepared width', () => {
+    const base = prepareWithSegments('Hello World', FONT)
+    const spaced = prepareWithSegments('Hello World', FONT, { letterSpacing: '2px' })
+
+    let baseTotal = 0
+    let spacedTotal = 0
+    for (let i = 0; i < base.widths.length; i++) baseTotal += base.widths[i]!
+    for (let i = 0; i < spaced.widths.length; i++) spacedTotal += spaced.widths[i]!
+    expect(spacedTotal).toBeGreaterThan(baseTotal)
+  })
+
+  test('letterSpacing cache separation: different spacing = different widths', () => {
+    const a = prepareWithSegments('Test', FONT, { letterSpacing: '1px' })
+    const b = prepareWithSegments('Test', FONT, { letterSpacing: '3px' })
+
+    expect(a.widths[0]).not.toBe(b.widths[0])
+  })
+
+  test('omitted letterSpacing equals "0px" letterSpacing', () => {
+    const base = prepareWithSegments('Hello World', FONT)
+    const zero = prepareWithSegments('Hello World', FONT, { letterSpacing: '0px' })
+
+    expect(zero.widths).toEqual(base.widths)
+  })
+
+  test('letterSpacing causes more line breaks at narrow widths', () => {
+    const base = prepare('The quick brown fox', FONT)
+    const spaced = prepare('The quick brown fox', FONT, { letterSpacing: '5px' })
+
+    const baseLines = layout(base, 200, LINE_HEIGHT).lineCount
+    const spacedLines = layout(spaced, 200, LINE_HEIGHT).lineCount
+    expect(spacedLines).toBeGreaterThan(baseLines)
+  })
+
+  test('letterSpacing applies to CJK text', () => {
+    const base = prepareWithSegments('春天到了', FONT)
+    const spaced = prepareWithSegments('春天到了', FONT, { letterSpacing: '4px' })
+
+    let baseTotal = 0
+    let spacedTotal = 0
+    for (let i = 0; i < base.widths.length; i++) baseTotal += base.widths[i]!
+    for (let i = 0; i < spaced.widths.length; i++) spacedTotal += spaced.widths[i]!
+    expect(spacedTotal).toBeGreaterThan(baseTotal)
   })
 })

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -150,6 +150,7 @@ export type WordBreakMode = AnalysisWordBreakMode
 export type PrepareOptions = {
   whiteSpace?: WhiteSpaceMode
   wordBreak?: WordBreakMode
+  letterSpacing?: string
 }
 
 // Internal hard-break chunk hint for the line walker. Not public because
@@ -318,11 +319,13 @@ function measureAnalysis(
   font: string,
   includeSegments: boolean,
   wordBreak: WordBreakMode,
+  letterSpacing?: string,
 ): InternalPreparedText | PreparedTextWithSegments {
   const engineProfile = getEngineProfile()
   const { cache, emojiCorrection } = getFontMeasurementState(
     font,
     textMayContainEmoji(analysis.normalized),
+    letterSpacing,
   )
   const discretionaryHyphenWidth = getCorrectedSegmentWidth('-', getSegmentMetrics('-', cache), emojiCorrection)
   const spaceWidth = getCorrectedSegmentWidth(' ', getSegmentMetrics(' ', cache), emojiCorrection)
@@ -539,7 +542,7 @@ function prepareInternal(
 ): InternalPreparedText | PreparedTextWithSegments {
   const wordBreak = options?.wordBreak ?? 'normal'
   const analysis = analyzeText(text, getEngineProfile(), options?.whiteSpace, wordBreak)
-  return measureAnalysis(analysis, font, includeSegments, wordBreak)
+  return measureAnalysis(analysis, font, includeSegments, wordBreak, options?.letterSpacing)
 }
 
 // Prepare text for layout. Segments the text, measures each segment via canvas,

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -127,12 +127,14 @@ export function textMayContainEmoji(text: string): boolean {
   return maybeEmojiRe.test(text)
 }
 
-function getEmojiCorrection(font: string, fontSize: number): number {
-  let correction = emojiCorrectionCache.get(font)
+function getEmojiCorrection(font: string, fontSize: number, letterSpacing?: string): number {
+  const cacheKey = letterSpacing ? `${font}:ls=${letterSpacing}` : font
+  let correction = emojiCorrectionCache.get(cacheKey)
   if (correction !== undefined) return correction
 
   const ctx = getMeasureContext()
   ctx.font = font
+  ;(ctx as any).letterSpacing = letterSpacing ?? '0px'
   const canvasW = ctx.measureText('\u{1F600}').width
   correction = 0
   if (
@@ -142,6 +144,7 @@ function getEmojiCorrection(font: string, fontSize: number): number {
   ) {
     const span = document.createElement('span')
     span.style.font = font
+    span.style.letterSpacing = letterSpacing ?? '0px'
     span.style.display = 'inline-block'
     span.style.visibility = 'hidden'
     span.style.position = 'absolute'
@@ -153,7 +156,7 @@ function getEmojiCorrection(font: string, fontSize: number): number {
       correction = canvasW - domW
     }
   }
-  emojiCorrectionCache.set(font, correction)
+  emojiCorrectionCache.set(cacheKey, correction)
   return correction
 }
 
@@ -263,16 +266,18 @@ export function getSegmentBreakableFitAdvances(
   return metrics.breakableFitAdvances
 }
 
-export function getFontMeasurementState(font: string, needsEmojiCorrection: boolean): {
+export function getFontMeasurementState(font: string, needsEmojiCorrection: boolean, letterSpacing?: string): {
   cache: Map<string, SegmentMetrics>
   fontSize: number
   emojiCorrection: number
 } {
   const ctx = getMeasureContext()
   ctx.font = font
-  const cache = getSegmentMetricCache(font)
+  ;(ctx as any).letterSpacing = letterSpacing ?? '0px'
+  const cacheKey = letterSpacing ? `${font}:ls=${letterSpacing}` : font
+  const cache = getSegmentMetricCache(cacheKey)
   const fontSize = parseFontSize(font)
-  const emojiCorrection = needsEmojiCorrection ? getEmojiCorrection(font, fontSize) : 0
+  const emojiCorrection = needsEmojiCorrection ? getEmojiCorrection(font, fontSize, letterSpacing) : 0
   return { cache, fontSize, emojiCorrection }
 }
 

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -266,6 +266,9 @@ export function getSegmentBreakableFitAdvances(
   return metrics.breakableFitAdvances
 }
 
+// Sets ctx.font and ctx.letterSpacing on the shared canvas context. Downstream
+// measurement functions (getSegmentMetrics, getSegmentBreakableFitAdvances) read
+// from this shared context, so this must be called before any measurement batch.
 export function getFontMeasurementState(font: string, needsEmojiCorrection: boolean, letterSpacing?: string): {
   cache: Map<string, SegmentMetrics>
   fontSize: number

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -134,7 +134,7 @@ function getEmojiCorrection(font: string, fontSize: number, letterSpacing?: stri
 
   const ctx = getMeasureContext()
   ctx.font = font
-  ;(ctx as any).letterSpacing = letterSpacing ?? '0px'
+  ctx.letterSpacing = letterSpacing ?? '0px'
   const canvasW = ctx.measureText('\u{1F600}').width
   correction = 0
   if (
@@ -273,7 +273,7 @@ export function getFontMeasurementState(font: string, needsEmojiCorrection: bool
 } {
   const ctx = getMeasureContext()
   ctx.font = font
-  ;(ctx as any).letterSpacing = letterSpacing ?? '0px'
+  ctx.letterSpacing = letterSpacing ?? '0px'
   const cacheKey = letterSpacing ? `${font}:ls=${letterSpacing}` : font
   const cache = getSegmentMetricCache(cacheKey)
   const fontSize = parseFontSize(font)


### PR DESCRIPTION
## Summary

Adds `letterSpacing?: string` to `PrepareOptions`. Instead of computing letter-spacing mathematically (as in #108), this sets `ctx.letterSpacing` on the Canvas context before `measureText()`, letting the browser engine handle exact width calculations natively.

```ts
const prepared = prepare(text, font, { letterSpacing: '2px' })
const { height } = layout(prepared, 300, 20)
```

I'd appreciate feedback on whether this direction aligns with what you had in mind when you noted "Leaving this open for actual support work" in cca3f1d.

## Approach

**Why Canvas native (`ctx.letterSpacing`, Baseline 2025.03):**
- `measureText()` automatically includes letter-spacing for all segment types — CJK, emoji, ligatures, relative units like `em`
- No grapheme counting, no trailing-trim edge cases
- Measurement concern stays in `measurement.ts`; `layout()` hot path and `line-break.ts` are untouched

**Why `letter-spacing` only:**
- `font-optical-sizing`, `font-feature-settings`, and `font-variation-settings` are not in the Canvas 2D spec
- The only alternative for those would be DOM fallback measurement, which contradicts the library's design
- Partially addressing #107 seemed better than blocking on the full set

## What changed

| File | Change |
|------|--------|
| `src/measurement.ts` | `ctx.letterSpacing` before measurement, cache key `:ls=<value>`, emoji correction with letterSpacing |
| `src/layout.ts` | `PrepareOptions` type + parameter threading (5 lines) |
| `src/layout.test.ts` | Mock Canvas update + 6 unit tests |
| `README.md` | Documentation update |

## Accuracy

I ran the browser accuracy sweep locally with letter-spacing variants (`1px`, `0.05em`, `-0.5px`) added:

|  | Chrome | Safari |
|--|--------|--------|
| **Base sweep** | 7680/7680 (100%) | 7680/7680 (100%) |
| **Letter-spacing sweep** | 22955/23040 (99.63%) | 22992/23040 (99.79%) |

The base sweep is completely unaffected. The letter-spacing mismatches are:

- **Arabic/RTL text** (84 in Chrome, 48 in Safari): The existing Canvas-vs-DOM Arabic shaping gap (currently absorbed by `lineFitEpsilon`) is amplified when letter-spacing widens per-segment widths past the epsilon boundary. Not new measurement bugs — the same fine-width field, made more visible by letter-spacing.

- **1 Latin overflow-wrap** (Verdana 24px, ls=1px, w=500, Chrome only): Cumulative rounding in the existing `sum-graphemes` `breakableFitAdvances` mode. Canvas prefix measurement and DOM agree on the break point; only the grapheme-sum path diverges.

I did not modify the accuracy sweep infrastructure — happy to add letter-spacing coverage to the sweep if you'd like, in whatever structure makes sense.

## Open questions

1. **Is Canvas native the right approach?** The alternative (PR #108's mathematical approximation) avoids the `ctx.letterSpacing` API dependency but has correctness issues at line boundaries. Happy to adjust if you prefer a different direction.

2. **Should `breakableFitAdvances` mode selection change when letterSpacing is active?** The one Latin mismatch would be resolved by using `segment-prefixes` instead of `sum-graphemes` for letter-spaced text, but that's a policy change I didn't want to make without input.

## Test plan

- [x] 94 unit tests pass (88 existing + 6 new letterSpacing tests)
- [x] TypeScript compiles cleanly (`ctx.letterSpacing` available in lib target)
- [x] Base accuracy sweep: 7680/7680 (100%) in Chrome and Safari — zero regression
- [x] `layout()` hot path, `line-break.ts`, `analysis.ts` unchanged

Partially addresses #107 (letter-spacing only).