### PR TITLE
chore: mark package as sideEffects: false to enable tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "git+https://github.com/chenglou/pretext.git"
   },
   "type": "module",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

Add `"sideEffects": false` to package.json so downstream bundlers can tree-shake unused exports of `@chenglou/pretext`.

## Why this matters

Per [#158](https://github.com/chenglou/pretext/issues/158), the `darkroomengineering/fitbox` maintainer's bundle audit shows ~129 KB of pretext modules ship to every consumer regardless of which exports they actually import:

| File | Size (raw) |
|---|---:|
| `analysis.js` | 37 KB |
| `line-break.js` | 33 KB |
| `generated/bidi-data.js` | 23 KB |
| `layout.js` | 22 KB |
| `measurement.js` | 8 KB |
| `bidi.js` | 6 KB |
| **Total** | **~129 KB raw** |

A consumer importing only `prepareWithSegments`, `measureNaturalWidth`, `measureLineStats`, `layoutWithLines` ships the full set today.

A scan of the published modules confirms there are no top-level side effects: `let sharedWordSegmenter = null` and the regex/Set initializers are pure expressions, evaluated lazily on first call. Marking the package side-effect-free is safe and lets bundlers drop unused exports based on what consumers import.

Realistic impact per #158: 20-40% bundle reduction for consumers using a subset of the API.

## Changes

One line in `package.json`:

```json
"sideEffects": false
```

## Testing

- `bun run build:package` — clean build
- `bun run check` — `tsc && oxlint --type-aware src` reports 0 warnings, 0 errors
- `bun test` — 103 pass, 0 fail (417 expect calls)

No source code touched, no behavior change.

Fixes #158
