### PR TITLE
fix: keep German low quotes with following word

### DIFF
--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -221,7 +221,7 @@ export const kinsokuStart = new Set([
 export const kinsokuEnd = new Set([
   '"',
   '(', '[', '{',
-  '“', '‘', '«', '‹',
+  '“', '‘', '«', '‹', '‚', '„',
   '\uFF08',
   '\u3014',
   '\u3008',

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -445,6 +445,19 @@ describe('prepare invariants', () => {
     expect(prepared.segments).toEqual(['“Whenever'])
   })
 
+  test('keeps German low opening quotes attached to the following word', () => {
+    for (const quote of ['‚', '„']) {
+      const prepared = prepareWithSegments(`aaaaaaaaaaaaaaaaaaa ${quote}Wort`, FONT)
+      expect(prepared.segments).toEqual(['aaaaaaaaaaaaaaaaaaa', ' ', `${quote}Wort`])
+
+      const strandedQuoteWidth = measureWidth(`aaaaaaaaaaaaaaaaaaa ${quote}`, FONT) + 0.1
+      expect(layoutWithLines(prepared, strandedQuoteWidth, LINE_HEIGHT).lines.map(line => line.text)).toEqual([
+        'aaaaaaaaaaaaaaaaaaa ',
+        `${quote}Wort`,
+      ])
+    }
+  })
+
   test('keeps apostrophe-led elisions attached to the following word', () => {
     const prepared = prepareWithSegments('“Take ’em downstairs', FONT)
     expect(prepared.segments).toEqual(['“Take', ' ', '’em', ' ', 'downstairs'])


### PR DESCRIPTION
## Summary
- Add German low opening quotes `‚` and `„` to `kinsokuEnd` so they stay attached to the following word.
- Add a regression test that verifies the low quote is not stranded at the end of a line.

## Validation
- `bun test src/layout.test.ts`
- `bun test`
- `bun run check`
- `bun run build:package`

Fixes #163