### PR TITLE
docs: translate corpora/README.md to Japanese

### DIFF
--- a/corpora/README.md
+++ b/corpora/README.md
@@ -1,129 +1,125 @@
 # Corpora
 
-Starter long-form stress corpora for browser-layout experiments.
+ブラウザレイアウト実験向けの長文ストレスコーパス初期セット。
 
-These files are checked in so we have stable canaries when probing languages and
-punctuation systems beyond the current 7680-case browser sweep. The main corpus
-set is wired into `/corpus` and the long-form rows on `/benchmark`; the status
-pages are the compact source of truth for current results.
+これらのファイルは、現行の 7680 ケースのブラウザスイープを超えて言語や句読法を調査する際に安定したカナリアを持てるよう、リポジトリにチェックインしてある。メインのコーパス群は `/corpus` と `/benchmark` の長文行に組み込まれており、ステータスページが現在の結果に関する簡潔な真実の源となる。
 
-Current bundle:
+現在のバンドル:
 
 - `mixed-app-text.txt`
-  - Language: mixed / app-style
-  - Source: synthetic corpus kept in-repo
-  - Acquisition: hand-curated stress text covering URLs, quote clusters, mixed RTL/LTR runs, emoji ZWJ, hard spaces, word joiners, zero-width breaks, and soft hyphens
+  - 言語: 混在 / アプリ風
+  - ソース: リポジトリ内に保持する合成コーパス
+  - 取得方法: URL、引用クラスタ、RTL/LTR の混在ラン、絵文字 ZWJ、ハードスペース、ワードジョイナ、ゼロ幅ブレイク、ソフトハイフンを網羅する手作業キュレーションのストレステキスト
 
 - `en-gatsby-opening.txt`
-  - Language: English
-  - Source: F. Scott Fitzgerald, `The Great Gatsby` opening
+  - 言語: 英語
+  - ソース: F. Scott Fitzgerald, `The Great Gatsby` 冒頭
   - URL: <https://www.gutenberg.org/ebooks/64317>
-  - Acquisition: checked-in copy of the long-form Gatsby canary text, now routed through the shared corpus tooling
+  - 取得方法: 長文 Gatsby カナリアテキストのチェックイン済みコピー。現在は共通コーパスツール経由でルーティング
 
 - `ja-rashomon.txt`
-  - Language: Japanese
-  - Source: 芥川龍之介, `羅生門`
+  - 言語: 日本語
+  - ソース: 芥川龍之介, `羅生門`
   - URL: <https://ja.wikisource.org/wiki/%E7%BE%85%E7%94%9F%E9%96%80>
-  - Acquisition: Wikisource `parse` API, trimmed to the story body with ruby readings and page/license scaffolding removed
+  - 取得方法: Wikisource `parse` API。ルビ表記とページ/ライセンスの足場を除去し、本文部分にトリミング
 
 - `ja-kumo-no-ito.txt`
-  - Language: Japanese
-  - Source: 芥川龍之介, `蜘蛛の糸`
+  - 言語: 日本語
+  - ソース: 芥川龍之介, `蜘蛛の糸`
   - URL: <https://ja.wikisource.org/wiki/%E8%9C%98%E8%9B%9B%E3%81%AE%E7%B3%B8>
-  - Acquisition: Wikisource `parse` API, trimmed to the story body with ruby fallout and public-domain/license scaffolding removed
+  - 取得方法: Wikisource `parse` API。ルビの残骸と PD/ライセンスの足場を除去し、本文部分にトリミング
 
 - `ko-unsu-joh-eun-nal.txt`
-  - Language: Korean
-  - Source: Hyun Jin-geon, `운수 좋은 날`
+  - 言語: 韓国語
+  - ソース: Hyun Jin-geon, `운수 좋은 날`
   - URL: <https://ko.wikisource.org/wiki/%EC%9A%B4%EC%88%98_%EC%A2%8B%EC%9D%80_%EB%82%A0>
-  - Acquisition: Wikisource `extracts` API, lightly cleaned
+  - 取得方法: Wikisource `extracts` API、軽くクリーンアップ
 
 - `ko-sonagi.txt`
-  - Language: Korean
-  - Source: Hwang Sun-won, `소나기`
+  - 言語: 韓国語
+  - ソース: Hwang Sun-won, `소나기`
   - URL: <https://ko.wikisource.org/wiki/%EC%86%8C%EB%82%98%EA%B8%B0>
-  - Acquisition: Wikisource `extracts` API, reformatted to remove fixed-width source wrapping
+  - 取得方法: Wikisource `extracts` API。固定幅のソース折り返しを除くよう再整形
 
 - `zh-zhufu.txt`
-  - Language: Chinese
-  - Source: 魯迅, `祝福`
+  - 言語: 中国語
+  - ソース: 魯迅, `祝福`
   - URL: <https://zh.wikisource.org/zh-hant/%E7%A5%9D%E7%A6%8F>
-  - Acquisition: Wikisource raw text, trimmed to the story body after removing the header template
+  - 取得方法: Wikisource の生テキスト。ヘッダテンプレートを除去後、本文部分にトリミング
 
 - `zh-guxiang.txt`
-  - Language: Chinese
-  - Source: 魯迅, `故鄉`
+  - 言語: 中国語
+  - ソース: 魯迅, `故鄉`
   - URL: <https://zh.wikisource.org/wiki/%E6%95%85%E9%84%89>
-  - Acquisition: Wikisource `parse` output, keeping only prose paragraphs after stripping page-number scaffolding and header tables
+  - 取得方法: Wikisource `parse` の出力。ページ番号の足場とヘッダテーブルを取り除き、散文段落のみ保持
 
 - `th-nithan-vetal-story-1.txt`
-  - Language: Thai
-  - Source: `นิทานเวตาล/เรื่องที่ 1`
+  - 言語: タイ語
+  - ソース: `นิทานเวตาล/เรื่องที่ 1`
   - URL: <https://th.wikisource.org/wiki/%E0%B8%99%E0%B8%B4%E0%B8%97%E0%B8%B2%E0%B8%99%E0%B9%80%E0%B8%A7%E0%B8%95%E0%B8%B2%E0%B8%A5/%E0%B9%80%E0%B8%A3%E0%B8%B7%E0%B9%88%E0%B8%AD%E0%B8%87%E0%B8%97%E0%B8%B5%E0%B9%88_1>
-  - Acquisition: Wikisource `parse` API, trimmed to the story body with header navigation and trailing footnote removed
+  - 取得方法: Wikisource `parse` API。ヘッダナビゲーションと末尾の脚注を除去し、本文部分にトリミング
 
 - `th-nithan-vetal-story-7.txt`
-  - Language: Thai
-  - Source: `นิทานเวตาล เรื่องที่ ๗`
+  - 言語: タイ語
+  - ソース: `นิทานเวตาล เรื่องที่ ๗`
   - URL: <https://th.wikisource.org/wiki/%E0%B8%99%E0%B8%B4%E0%B8%97%E0%B8%B2%E0%B8%99%E0%B9%80%E0%B8%A7%E0%B8%95%E0%B8%B2%E0%B8%A5_%E0%B9%80%E0%B8%A3%E0%B8%B7%E0%B9%88%E0%B8%AD%E0%B8%87%E0%B8%97%E0%B8%B5%E0%B9%88_%E0%B9%97>
-  - Acquisition: Wikisource `parse` API, trimmed to the story body after removing navigation and header scaffolding
+  - 取得方法: Wikisource `parse` API。ナビゲーションとヘッダの足場を除去し、本文部分にトリミング
 
 - `my-cunning-heron-teacher.txt`
-  - Language: Myanmar
-  - Source: `စဉ်းလဲသော ဗျိုင်း (ဆရာ)`
+  - 言語: ミャンマー語
+  - ソース: `စဉ်းလဲသော ဗျိုင်း (ဆရာ)`
   - URL: <https://my.wikisource.org/wiki/%E1%80%85%E1%80%89%E1%80%BA%E1%80%B8%E1%80%9C%E1%80%B2%E1%80%9E%E1%80%B1%E1%80%AC_%E1%80%97%E1%80%BB%E1%80%AD%E1%80%AF%E1%80%84%E1%80%BA%E1%80%B8_(%E1%80%86%E1%80%9B%E1%80%AC)>
-  - Acquisition: Wikisource `parse` API, trimmed to the story body only and excluding the teaching-guide scaffolding
+  - 取得方法: Wikisource `parse` API。本文部分のみにトリミングし、教則ガイドの足場を除外
 
 - `my-bad-deeds-return-to-you-teacher.txt`
-  - Language: Myanmar
-  - Source: `မကောင်းမှုဒဏ် ကိုယ့်ထံပြန် (ဆရာ)`
+  - 言語: ミャンマー語
+  - ソース: `မကောင်းမှုဒဏ် ကိုယ့်ထံပြန် (ဆရာ)`
   - URL: <https://my.wikisource.org/wiki/%E1%80%99%E1%80%80%E1%80%B1%E1%80%AC%E1%80%84%E1%80%BA%E1%80%B8%E1%80%99%E1%80%BE%E1%80%AF%E1%80%92%E1%80%8F%E1%80%BA_%E1%80%80%E1%80%AD%E1%80%AF%E1%80%9A%E1%80%B7%E1%80%BA%E1%80%91%E1%80%B6%E1%80%95%E1%80%BC%E1%80%94%E1%80%BA_(%E1%80%86%E1%80%9B%E1%80%AC)>
-  - Acquisition: Wikisource raw page, trimmed to the story body only and excluding the teacher-guide scaffolding, references, and questions
+  - 取得方法: Wikisource の生ページ。本文部分のみにトリミングし、教師ガイドの足場・参考文献・問題を除外
 
 - `km-prachum-reuang-preng-khmer-volume-7-stories-1-10.txt`
-  - Language: Khmer
-  - Source: `ប្រជុំរឿងព្រេងខ្មែរ/ភាគទី៧`
+  - 言語: クメール語
+  - ソース: `ប្រជុំរឿងព្រេងខ្មែរ/ភាគទី៧`
   - URL: <https://wikisource.org/wiki/%E1%9E%94%E1%9F%92%E1%9E%9A%E1%9E%87%E1%9E%BB%E1%9F%86%E1%9E%9A%E1%9E%BF%E1%9E%84%E1%9E%96%E1%9F%92%E1%9E%9A%E1%9F%81%E1%9E%84%E1%9E%81%E1%9F%92%E1%9E%98%E1%9F%82%E1%9E%9A/%E1%9E%97%E1%9E%B6%E1%9E%82%E1%9E%91%E1%9E%B8%E1%9F%A7>
-  - Acquisition: rendered-page HTML cleanup, combining stories 1-10 after trimming navigation/header scaffolding
+  - 取得方法: レンダリング済みページ HTML のクリーンアップ。ナビゲーション/ヘッダの足場を除去後、第 1 話から第 10 話までを結合
 
 - `ar-risalat-al-ghufran-part-1.txt`
-  - Language: Arabic
-  - Source: Al-Ma'arri, `رسالة الغفران/الجزء الأول`
+  - 言語: アラビア語
+  - ソース: Al-Ma'arri, `رسالة الغفران/الجزء الأول`
   - URL: <https://ar.wikisource.org/wiki/%D8%B1%D8%B3%D8%A7%D9%84%D8%A9_%D8%A7%D9%84%D8%BA%D9%81%D8%B1%D8%A7%D9%86/%D8%A7%D9%84%D8%AC%D8%B2%D8%A1_%D8%A7%D9%84%D8%A3%D9%88%D9%84>
-  - Acquisition: Wikisource `extracts` API
+  - 取得方法: Wikisource `extracts` API
 
 - `ar-al-bukhala.txt`
-  - Language: Arabic
-  - Source: Al-Jahiz, `البخلاء`
+  - 言語: アラビア語
+  - ソース: Al-Jahiz, `البخلاء`
   - URL: <https://ar.wikisource.org/wiki/%D8%A7%D9%84%D8%A8%D8%AE%D9%84%D8%A7%D8%A1>
-  - Acquisition: Wikisource `parse` API, trimmed to the real prose after the table of contents
+  - 取得方法: Wikisource `parse` API。目次以降の実散文部分にトリミング
 
 - `hi-eidgah.txt`
-  - Language: Hindi
-  - Source: Premchand, `प्रेमचंद की सर्वश्रेष्ठ कहानियां/ईदगाह`
+  - 言語: ヒンディー語
+  - ソース: Premchand, `प्रेमचंद की सर्वश्रेष्ठ कहानियां/ईदगाह`
   - URL: <https://hi.wikisource.org/wiki/%E0%A4%AA%E0%A5%8D%E0%A4%B0%E0%A5%87%E0%A4%AE%E0%A4%9A%E0%A4%82%E0%A4%A6_%E0%A4%95%E0%A5%80_%E0%A4%B8%E0%A4%B0%E0%A5%8D%E0%A4%B5%E0%A4%B6%E0%A5%8D%E0%A4%B0%E0%A5%87%E0%A4%B7%E0%A5%8D%E0%A4%A0_%E0%A4%95%E0%A4%B9%E0%A4%BE%E0%A4%A8%E0%A4%BF%E0%A4%AF%E0%A4%BE%E0%A4%82/%E0%A4%88%E0%A4%A6%E0%A4%97%E0%A4%BE%E0%A4%B9>
-  - Acquisition: Wikisource `parse` API with simple HTML-to-text cleanup
+  - 取得方法: Wikisource `parse` API。シンプルな HTML→テキスト変換でクリーンアップ
 
 - `he-masaot-binyamin-metudela.txt`
-  - Language: Hebrew
-  - Source: `מסעות בנימין מטודלה`
+  - 言語: ヘブライ語
+  - ソース: `מסעות בנימין מטודלה`
   - URL: <https://he.wikisource.org/wiki/%D7%9E%D7%A1%D7%A2%D7%95%D7%AA_%D7%91%D7%A0%D7%99%D7%9E%D7%99%D7%9F_%D7%9E%D7%98%D7%95%D7%93%D7%9C%D7%94>
-  - Acquisition: Wikisource `parse` API, trimmed to the fully transcribed portion with editorial bracket notes removed
+  - 取得方法: Wikisource `parse` API。完全に翻刻された部分にトリミングし、編集者の角括弧注を除去
 
 - `ur-chughd.txt`
-  - Language: Urdu
-  - Source: سعادت حسن منٹو, `چغد`
+  - 言語: ウルドゥー語
+  - ソース: سعادت حسن منٹو, `چغد`
   - URL: <https://wikisource.org/wiki/%DA%86%D8%BA%D8%AF_(%D8%A7%D9%81%D8%B3%D8%A7%D9%86%DB%81)>
-  - Acquisition: Wikisource `parse` API, extracted from prose paragraphs only and stripped of header scaffolding and numbered section markers
+  - 取得方法: Wikisource `parse` API。散文段落のみを抽出し、ヘッダの足場と番号付きセクションマーカーを除去
 
-Machine-readable metadata lives in `sources.json`.
+機械可読のメタデータは `sources.json` にある。
 
-Current sweep status lives in `STATUS.md`.
-Machine-readable corpus status lives in `dashboard.json`, and its main snapshot
-inputs are `chrome-step10.json` and `safari-step10.json`.
-Mismatch taxonomy and steering vocabulary live in `TAXONOMY.md`.
+現在のスイープ状況は `STATUS.md` にある。
+機械可読のコーパスステータスは `dashboard.json` にあり、その主要スナップショットの入力は `chrome-step10.json` と `safari-step10.json`。
+ミスマッチの分類体系と方向付け用語彙は `TAXONOMY.md` にある。
 
-Useful commands:
+便利なコマンド:
 
 - `bun run corpus-check --id=ko-unsu-joh-eun-nal 300 600 800`
 - `bun run corpus-check --id=ko-sonagi 300 600 800`
@@ -132,4 +128,4 @@ Useful commands:
 - `bun run corpus-sweep --id=ar-al-bukhala --start=300 --end=900 --step=10`
 - `bun run corpus-sweep --all --start=300 --end=900 --step=10`
 
-The corpus page is also available locally at `/corpus?id=<corpus-id>`.
+コーパスページはローカルでも `/corpus?id=<corpus-id>` で利用できる。


### PR DESCRIPTION
ユーザーの要望でリポジトリ内 MD ファイルを並列和訳する一環。コードブロック・パス・URL は保持済み。