### PR TITLE
Fix rich-inline punctuation boundary wrapping

### DIFF
--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -960,6 +960,30 @@ describe('rich-inline invariants', () => {
     })
   })
 
+  test('rich inline keeps line-start punctuation attached across item boundaries', () => {
+    const prepared = prepareRichInline([
+      { text: 'Hello', font: FONT },
+      { text: '.', font: FONT },
+      { text: ' world', font: FONT },
+    ])
+    const maxWidth = measureWidth('Hello', FONT) + 0.1
+    const lines: string[] = []
+    const widths: number[] = []
+
+    walkRichInlineLineRanges(prepared, maxWidth, range => {
+      const line = materializeRichInlineLineRange(prepared, range)
+      lines.push(line.fragments.map(fragment => fragment.text).join(''))
+      widths.push(line.width)
+    })
+
+    expect(lines).toEqual(['Hello.', 'world'])
+    expect(widths[0]!).toBeCloseTo(measureWidth('Hello.', FONT), 5)
+    expect(measureRichInlineStats(prepared, maxWidth)).toEqual({
+      lineCount: lines.length,
+      maxLineWidth: Math.max(...widths),
+    })
+  })
+
   test('split CJK rich inline items stay inside the line width', () => {
     const maxWidth = measureWidth('中', FONT) + 1
     const prepared = prepareRichInline([

--- a/src/rich-inline.ts
+++ b/src/rich-inline.ts
@@ -1,4 +1,8 @@
 import {
+  kinsokuStart,
+  leftStickyPunctuation,
+} from './analysis.js'
+import {
   measureNaturalWidth,
   prepareWithSegments,
   type PreparedTextWithSegments,
@@ -153,6 +157,31 @@ type RichInlineFragmentCollector = (
 
 function endsInsideFirstSegment(segmentIndex: number, graphemeIndex: number): boolean {
   return segmentIndex === 0 && graphemeIndex > 0
+}
+
+function startsWithLineStartProhibitedText(item: PreparedRichInlineItem): boolean {
+  const firstSegment = item.prepared.segments[0]
+  if (firstSegment === undefined) return false
+
+  const firstChar = Array.from(firstSegment)[0]
+  return firstChar !== undefined && (
+    leftStickyPunctuation.has(firstChar) ||
+    kinsokuStart.has(firstChar)
+  )
+}
+
+function shouldKeepItemAttachedToCurrentLine(
+  item: PreparedRichInlineItem,
+  gapBefore: number,
+  lineWidth: number,
+  atItemStart: boolean,
+): boolean {
+  return (
+    lineWidth > 0 &&
+    atItemStart &&
+    gapBefore === 0 &&
+    startsWithLineStartProhibitedText(item)
+  )
 }
 
 export function prepareRichInline(items: RichInlineItem[]): PreparedRichInline {
@@ -332,7 +361,14 @@ function stepRichInlineLine(
 
     // The lower-level walker may force one unit to make progress. If that unit
     // only fits on a fresh line, wrap before this rich item instead.
-    if (lineWidth > 0 && atItemStart && lineWidthContribution > remainingWidth) break lineLoop
+    if (
+      lineWidth > 0 &&
+      atItemStart &&
+      lineWidthContribution > remainingWidth &&
+      !shouldKeepItemAttachedToCurrentLine(item, gapBefore, lineWidth, atItemStart)
+    ) {
+      break lineLoop
+    }
 
     // If the only thing we can fit after paying the boundary gap is a partial
     // slice of the item's first segment, prefer wrapping before the item so we


### PR DESCRIPTION
## Summary
- Keep rich-inline item boundaries from wrapping before line-start-prohibited punctuation when there is no collapsed whitespace gap.
- Reuse the core punctuation sets so split inline items such as `Hello` + `.` stay attached.
- Add a regression test covering materialized rich-inline lines and stats.

## Why
Adjacent inline items should not introduce an extra line break before punctuation that browsers keep attached to the previous text node. This addresses #177.

## Validation
- `/home/luyh7/tmp/.tools/bun-1.3.14/package/bin/bun test src/layout.test.ts`
- `node node_modules/typescript/bin/tsc --noEmit`
- `node node_modules/typescript/bin/tsc -p tsconfig.build.json`
- `git diff --check`