### PR TITLE
fix: break overlong symbol runs

### DIFF
--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -662,6 +662,15 @@ describe('prepare invariants', () => {
     expect(prepared.segments).toEqual([text])
   })
 
+  test('breaks overlong repeated symbol runs at grapheme boundaries', () => {
+    const prepared = prepareWithSegments('||||', FONT)
+    const maxWidth = measureWidth('|', FONT) + 0.1
+    const lines = layoutWithLines(prepared, maxWidth, LINE_HEIGHT).lines
+
+    expect(lines.map(line => line.text)).toEqual(['|', '|', '|', '|'])
+    expect(lines.every(line => line.width <= maxWidth)).toBe(true)
+  })
+
   test('keeps repeated punctuation runs attachable to trailing closing punctuation', () => {
     const prepared = prepareWithSegments('((()', FONT)
     expect(prepared.segments).toEqual(['((()'])

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -450,7 +450,6 @@ function measureAnalysis(
     textMetrics: SegmentMetrics,
     kind: SegmentBreakKind,
     start: number,
-    wordLike: boolean,
     allowOverflowBreaks: boolean,
   ): void {
     const spacingGraphemeCount = hasLetterSpacing
@@ -474,7 +473,7 @@ function measureAnalysis(
         ? 0
         : width
 
-    if (allowOverflowBreaks && wordLike && text.length > 1) {
+    if (allowOverflowBreaks && kind === 'text' && text.length > 1) {
       let fitMode: BreakableFitMode = 'sum-graphemes'
       if (letterSpacing !== 0) {
         fitMode = 'segment-prefixes'
@@ -523,7 +522,6 @@ function measureAnalysis(
 
   for (let mi = 0; mi < analysis.len; mi++) {
     const segText = analysis.texts[mi]!
-    const segWordLike = analysis.isWordLike[mi]!
     const segKind = analysis.kinds[mi]!
     const segStart = analysis.starts[mi]!
 
@@ -585,14 +583,13 @@ function measureAnalysis(
           unitMetrics,
           'text',
           segStart + unit.start,
-          segWordLike,
           wordBreak === 'keep-all' || !unitMetrics.containsCJK,
         )
       }
       continue
     }
 
-    pushMeasuredTextSegment(segText, segMetrics, segKind, segStart, segWordLike, true)
+    pushMeasuredTextSegment(segText, segMetrics, segKind, segStart, true)
   }
 
   if (chunkStartSegmentIndex < widths.length) {


### PR DESCRIPTION
Summary:
- Allow multi-grapheme text segments that are not word-like to get overflow break advances.
- Add regression coverage for repeated symbol runs wrapping at grapheme boundaries.

Validation:
- /Users/sandog/.real/.bin/bun test src/layout.test.ts
- /Users/sandog/.real/.bin/bun run check

Fixes #206