### PR TITLE
fix: preserve leading ZWSP so zero-width-only lines are not dropped

### DIFF
--- a/src/line-break.ts
+++ b/src/line-break.ts
@@ -34,7 +34,12 @@ type InternalLineVisitor = (
 ) => void
 
 function consumesAtLineStart(kind: SegmentBreakKind): boolean {
-  return kind === 'space' || kind === 'zero-width-break' || kind === 'soft-hyphen'
+  // ZWSP is not CSS-collapsible whitespace: it is zero-width content that
+  // survives on the line and offers a break opportunity after it. When the
+  // next word overflows, the browser breaks after the ZWSP, producing a line
+  // that holds only the ZWSP. Consuming it at line start would under-count
+  // that line versus real rendering.
+  return kind === 'space' || kind === 'soft-hyphen'
 }
 
 function breaksAfter(kind: SegmentBreakKind): boolean {

--- a/src/rich-inline.ts
+++ b/src/rich-inline.ts
@@ -232,6 +232,12 @@ function stepRichInlineLine(
   let lineWidth = 0
   let remainingWidth = safeWidth
   let itemIndex = cursor.itemIndex
+  // Zero-width fragments (e.g. a leading ZWSP alone on a line) do not add to
+  // lineWidth but still consume the cursor and form a real line. Track via a
+  // consumed flag rather than lineWidth === 0, otherwise the zero-width line
+  // is dropped and the caller terminates layout early because the cursor
+  // never advanced.
+  let consumedAnyFragment = false
 
   lineLoop:
   while (itemIndex < flow.items.length) {
@@ -262,6 +268,7 @@ function stepRichInlineLine(
       const totalWidth = gapBefore + occupiedWidth
       if (lineWidth > 0 && totalWidth > remainingWidth) break lineLoop
 
+      consumedAnyFragment = true
       collectFragment?.(
         item,
         gapBefore,
@@ -286,6 +293,7 @@ function stepRichInlineLine(
     if (atItemStart) {
       const totalWidth = reservedWidth + item.naturalWidth
       if (totalWidth <= remainingWidth) {
+        consumedAnyFragment = true
         collectFragment?.(
           item,
           gapBefore,
@@ -365,6 +373,7 @@ function stepRichInlineLine(
       }
     }
 
+    consumedAnyFragment = true
     collectFragment?.(
       item,
       gapBefore,
@@ -393,7 +402,7 @@ function stepRichInlineLine(
     break
   }
 
-  if (lineWidth === 0) return null
+  if (!consumedAnyFragment) return null
 
   cursor.itemIndex = itemIndex
   return lineWidth


### PR DESCRIPTION
fix #210.
ZWSP was folded at line start like CSS-collapsible whitespace, so a line holding only the ZWSP was dropped and layout under-counted it versus real rendering. Keep ZWSP at line start and track fragment consumption separately from line width in the rich inline walker.