### PR TITLE
feat: expose fontKerning option in prepare()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `prepare()` / `prepareWithSegments()` accept `{ fontKerning: 'auto' | 'normal' | 'none' }` so measurement can match the caller's rendered canvas/CSS kerning mode (#199).
+
 ### Changed
 
 - Safari soft-hyphen wrapping now follows the same strict insertion-point behavior across `layout()`, rich-line, and streaming APIs. The Safari compatibility profile was revalidated on Safari 26.4, after previously being validated through Safari 26.3.1.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const prepared = prepare(textareaValue, '16px Inter', { whiteSpace: 'pre-wrap' }
 const { height } = layout(prepared, textareaWidth, 20)
 ```
 
-Other `prepare()` options are `{ wordBreak: 'keep-all' }` for CSS-like `word-break: keep-all`, and `{ letterSpacing: n }` to match CSS `letter-spacing` (`n` is treated as a px value).
+Other `prepare()` options are `{ wordBreak: 'keep-all' }` for CSS-like `word-break: keep-all`, `{ letterSpacing: n }` to match CSS `letter-spacing` (`n` is treated as a px value), and `{ fontKerning: 'auto' | 'normal' | 'none' }` to match canvas/CSS `font-kerning` while measuring.
 
 The returned height is the crucial last piece for unlocking web UIs:
 - proper virtualization/occlusion without guesstimates & caching
@@ -124,13 +124,13 @@ It is intentionally narrow:
 
 Use-case 1 APIs:
 ```ts
-prepare(text: string, font: string, options?: { whiteSpace?: 'normal' | 'pre-wrap', wordBreak?: 'normal' | 'keep-all', letterSpacing?: number }): PreparedText // one-time text analysis + measurement pass, returns an opaque value to pass to `layout()`. Make sure `font` and `letterSpacing` are synced with your CSS for the text you're measuring. `font` is the same format as what you'd use for `myCanvasContext.font = ...`, e.g. `16px Inter`; `letterSpacing` is a CSS pixel value.
+prepare(text: string, font: string, options?: { whiteSpace?: 'normal' | 'pre-wrap', wordBreak?: 'normal' | 'keep-all', letterSpacing?: number, fontKerning?: 'auto' | 'normal' | 'none' }): PreparedText // one-time text analysis + measurement pass, returns an opaque value to pass to `layout()`. Make sure `font`, `letterSpacing`, and `fontKerning` are synced with your CSS/canvas for the text you're measuring. `font` is the same format as what you'd use for `myCanvasContext.font = ...`, e.g. `16px Inter`; `letterSpacing` is a CSS pixel value; `fontKerning` defaults to `'auto'`.
 layout(prepared: PreparedText, maxWidth: number, lineHeight: number): { height: number, lineCount: number } // calculates text height given a max width and lineHeight. Make sure `lineHeight` is synced with your css `line-height` declaration for the text you're measuring.
 ```
 
 Use-case 2 APIs:
 ```ts
-prepareWithSegments(text: string, font: string, options?: { whiteSpace?: 'normal' | 'pre-wrap', wordBreak?: 'normal' | 'keep-all', letterSpacing?: number }): PreparedTextWithSegments // same as `prepare()`, but returns a richer structure for manual line layout needs
+prepareWithSegments(text: string, font: string, options?: { whiteSpace?: 'normal' | 'pre-wrap', wordBreak?: 'normal' | 'keep-all', letterSpacing?: number, fontKerning?: 'auto' | 'normal' | 'none' }): PreparedTextWithSegments // same as `prepare()`, but returns a richer structure for manual line layout needs
 layoutWithLines(prepared: PreparedTextWithSegments, maxWidth: number, lineHeight: number): { height: number, lineCount: number, lines: LayoutLine[] } // high-level api for manual layout needs. Accepts a fixed max width for all lines. Similar to `layout()`'s return, but additionally returns the lines info
 walkLineRanges(prepared: PreparedTextWithSegments, maxWidth: number, onLine: (line: LayoutLineRange) => void): number // low-level api for manual layout needs. Accepts a fixed max width for all lines. Calls `onLine` once per line with its actual calculated line width and start/end cursors, without building line text strings. Very useful for certain cases where you wanna speculatively test a few width and height boundaries (e.g. binary search a nice width value by repeatedly calling walkLineRanges and checking the line count, and therefore height, is "nice" too). You can have text messages shrinkwrap and balanced text layout this way. After walkLineRanges calls, you'd call layoutWithLines once, with your satisfying max width, to get the actual lines info.
 measureLineStats(prepared: PreparedTextWithSegments, maxWidth: number): { lineCount: number, maxLineWidth: number } // returns only how many lines this width produces, and how wide the widest one is. Avoids line/string allocations.

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -91,7 +91,11 @@ function isWideCharacter(ch: string): boolean {
   )
 }
 
-function measureWidth(text: string, font: string): number {
+function measureWidth(
+  text: string,
+  font: string,
+  fontKerning: 'auto' | 'normal' | 'none' = 'auto',
+): number {
   const fontSize = parseFontSize(font)
   let width = 0
   let previousWasDecimalDigit = false
@@ -119,6 +123,11 @@ function measureWidth(text: string, font: string): number {
       width += fontSize * 0.6
       previousWasDecimalDigit = false
     }
+  }
+
+  // Fake kerning pair: browsers typically tighten "AV" under auto/normal.
+  if (fontKerning !== 'none' && text.includes('AV')) {
+    width -= fontSize * 0.15 * (text.split('AV').length - 1)
   }
 
   return width
@@ -252,9 +261,10 @@ function getNonSpaceSegmentLevels(
 
 class TestCanvasRenderingContext2D {
   font = ''
+  fontKerning: 'auto' | 'normal' | 'none' = 'auto'
 
   measureText(text: string): { width: number } {
-    return { width: measureWidth(text, this.font) }
+    return { width: measureWidth(text, this.font, this.fontKerning) }
   }
 }
 
@@ -298,6 +308,22 @@ beforeAll(async () => {
 beforeEach(() => {
   setLocale(undefined)
   clearCache()
+})
+
+describe('fontKerning prepare option', () => {
+  test('fontKerning none widens kerning pairs relative to auto', () => {
+    const auto = prepareWithSegments('AV', FONT)
+    const none = prepareWithSegments('AV', FONT, { fontKerning: 'none' })
+    expect(none.widths[0]!).toBeGreaterThan(auto.widths[0]!)
+  })
+
+  test('fontKerning caches stay isolated across modes', () => {
+    const autoFirst = prepareWithSegments('AV', FONT, { fontKerning: 'auto' })
+    const none = prepareWithSegments('AV', FONT, { fontKerning: 'none' })
+    const autoAgain = prepareWithSegments('AV', FONT, { fontKerning: 'auto' })
+    expect(autoAgain.widths[0]).toBe(autoFirst.widths[0])
+    expect(none.widths[0]!).toBeGreaterThan(autoFirst.widths[0]!)
+  })
 })
 
 describe('measurement invariants', () => {

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -51,6 +51,7 @@ import {
 } from './analysis.js'
 import {
   type BreakableFitMode,
+  type FontKerningMode,
   clearMeasurementCaches,
   getCorrectedSegmentWidth,
   getSegmentBreakableFitAdvances,
@@ -60,6 +61,8 @@ import {
   textMayContainEmoji,
   type SegmentMetrics,
 } from './measurement.js'
+
+export type { FontKerningMode }
 import {
   countPreparedLines,
   measurePreparedLineGeometry,
@@ -154,6 +157,8 @@ export type PrepareOptions = {
   whiteSpace?: WhiteSpaceMode
   wordBreak?: WordBreakMode
   letterSpacing?: number
+  /** Canvas `fontKerning` used while measuring. Default `'auto'`. */
+  fontKerning?: FontKerningMode
 }
 
 // Internal hard-break chunk hint for the line walker. Not public because
@@ -392,11 +397,13 @@ function measureAnalysis(
   includeSegments: boolean,
   wordBreak: WordBreakMode,
   letterSpacing: number,
+  fontKerning: FontKerningMode,
 ): InternalPreparedText | PreparedTextWithSegments {
   const engineProfile = getEngineProfile()
   const { cache, emojiCorrection } = getFontMeasurementState(
     font,
     textMayContainEmoji(analysis.normalized),
+    fontKerning,
   )
   const discretionaryHyphenWidth =
     getCorrectedSegmentWidth('-', getSegmentMetrics('-', cache), emojiCorrection) +
@@ -646,8 +653,9 @@ function prepareInternal(
 ): InternalPreparedText | PreparedTextWithSegments {
   const wordBreak = options?.wordBreak ?? 'normal'
   const letterSpacing = options?.letterSpacing ?? 0
+  const fontKerning = options?.fontKerning ?? 'auto'
   const analysis = analyzeText(text, getEngineProfile(), options?.whiteSpace, wordBreak)
-  return measureAnalysis(analysis, font, includeSegments, wordBreak, letterSpacing)
+  return measureAnalysis(analysis, font, includeSegments, wordBreak, letterSpacing, fontKerning)
 }
 
 // Prepare text for layout. Segments the text, measures each segment via canvas,

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -17,9 +17,16 @@ export type EngineProfile = {
 
 export type BreakableFitMode = 'sum-graphemes' | 'segment-prefixes' | 'pair-context'
 
+export type FontKerningMode = 'auto' | 'normal' | 'none'
+
 let measureContext: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null = null
 const segmentMetricCaches = new Map<string, Map<string, SegmentMetrics>>()
 let cachedEngineProfile: EngineProfile | null = null
+
+function measurementCacheKey(font: string, fontKerning: FontKerningMode): string {
+  // Keep the common default on the plain font key so existing caches stay hit.
+  return fontKerning === 'auto' ? font : `${font}\0fontKerning=${fontKerning}`
+}
 
 // Safari's prefix-fit policy is useful for ordinary word-sized runs, but letting
 // it measure every growing prefix of a giant segment recreates a pathological
@@ -48,11 +55,15 @@ export function getMeasureContext(): CanvasRenderingContext2D | OffscreenCanvasR
   throw new Error('Text measurement requires OffscreenCanvas or a DOM canvas context.')
 }
 
-export function getSegmentMetricCache(font: string): Map<string, SegmentMetrics> {
-  let cache = segmentMetricCaches.get(font)
+export function getSegmentMetricCache(
+  font: string,
+  fontKerning: FontKerningMode = 'auto',
+): Map<string, SegmentMetrics> {
+  const key = measurementCacheKey(font, fontKerning)
+  let cache = segmentMetricCaches.get(key)
   if (!cache) {
     cache = new Map()
-    segmentMetricCaches.set(font, cache)
+    segmentMetricCaches.set(key, cache)
   }
   return cache
 }
@@ -252,14 +263,23 @@ export function getSegmentBreakableFitAdvances(
   return metrics.breakableFitAdvances
 }
 
-export function getFontMeasurementState(font: string, needsEmojiCorrection: boolean): {
+export function getFontMeasurementState(
+  font: string,
+  needsEmojiCorrection: boolean,
+  fontKerning: FontKerningMode = 'auto',
+): {
   cache: Map<string, SegmentMetrics>
   fontSize: number
   emojiCorrection: number
 } {
   const ctx = getMeasureContext()
   ctx.font = font
-  const cache = getSegmentMetricCache(font)
+  // Align canvas measurement with the caller's rendered kerning mode. The
+  // shared context is reused across prepares, so this must be set every call.
+  if ('fontKerning' in ctx) {
+    ctx.fontKerning = fontKerning
+  }
+  const cache = getSegmentMetricCache(font, fontKerning)
   const fontSize = parseFontSize(font)
   const emojiCorrection = needsEmojiCorrection ? getEmojiCorrection(font, fontSize) : 0
   return { cache, fontSize, emojiCorrection }


### PR DESCRIPTION
## Summary

Fixes #199 by letting `prepare()` / `prepareWithSegments()` set canvas `fontKerning` while measuring.

Pretext's value is accurate measurement without DOM reflow, but measurement was always locked to the browser default kerning (`auto`). Consumers that paint with `font-kerning: none` / `ctx.fontKerning = 'none'` could not align widths.

### Changes

- Add `PrepareOptions.fontKerning?: 'auto' | 'normal' | 'none'` (default `'auto'`).
- Apply `ctx.fontKerning` in `getFontMeasurementState` on every prepare.
- Key the segment metric cache by font + kerning mode (default path keeps the plain font key).
- Document in README / CHANGELOG; unit tests with a fake canvas that models a kerning pair.

### Test plan

- [x] Unit: `fontKerning: 'none'` widens `AV` vs default; caches stay isolated.
- [ ] Package test suite / CI
