### PR TITLE
perf: minor optimizations in benchmark and build scripts

### DIFF
--- a/scripts/benchmark-check.ts
+++ b/scripts/benchmark-check.ts
@@ -96,8 +96,8 @@ function parseBrowser(value: string | null): BrowserKind {
 
 function median(values: number[]): number {
   const sorted = [...values].sort((a, b) => a - b)
-  const mid = Math.floor(sorted.length / 2)
-  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!
+  const mid = sorted.length >> 1
+  return sorted.length & 1 ? sorted[mid]! : (sorted[mid - 1]! + sorted[mid]!) / 2
 }
 
 function assertSame<T>(actual: T, expected: T, context: string): void {

--- a/scripts/build-demo-site.ts
+++ b/scripts/build-demo-site.ts
@@ -25,7 +25,7 @@ const result = Bun.spawnSync(
   },
 )
 
-if (result.exitCode !== 0) {
+if (result.exitCode) {
   process.exit(result.exitCode)
 }
 


### PR DESCRIPTION
Implements minor optimizations suggested in issue #179.

Changes:
- Use bitwise shift instead of Math.floor division in median()
- Use bitwise AND for parity check instead of modulo
- Simplify exitCode check to truthy test

Closes #179