### PR TITLE
fix: break overlong symbol runs at grapheme boundaries

### DIFF
--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -662,6 +662,22 @@ describe('prepare invariants', () => {
     expect(prepared.segments).toEqual([text])
   })
 
+  test('breaks overlong symbol runs at grapheme boundaries', () => {
+    const pipeWidth = measureWidth('|', FONT)
+    const maxWidth = pipeWidth + 0.1
+
+    const simplePrepared = prepareWithSegments('||||', FONT)
+    const simpleLines = layoutWithLines(simplePrepared, maxWidth, LINE_HEIGHT).lines
+    expect(simpleLines.map(l => l.text)).toEqual(['|', '|', '|', '|'])
+    expect(simpleLines.every(l => l.width <= maxWidth)).toBe(true)
+
+    const mixedSymbols = '{{{]]]\\\|||'
+    const mixedPrepared = prepareWithSegments(mixedSymbols, FONT)
+    const mixedLines = layoutWithLines(mixedPrepared, maxWidth, LINE_HEIGHT).lines
+    expect(mixedLines.every(l => l.width <= maxWidth)).toBe(true)
+    expect(mixedLines.map(l => l.text)).toEqual(getSegmentGraphemes(mixedSymbols))
+  })
+
   test('keeps repeated punctuation runs attachable to trailing closing punctuation', () => {
     const prepared = prepareWithSegments('((()', FONT)
     expect(prepared.segments).toEqual(['((()'])

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -450,7 +450,6 @@ function measureAnalysis(
     textMetrics: SegmentMetrics,
     kind: SegmentBreakKind,
     start: number,
-    wordLike: boolean,
     allowOverflowBreaks: boolean,
   ): void {
     const spacingGraphemeCount = hasLetterSpacing
@@ -474,7 +473,7 @@ function measureAnalysis(
         ? 0
         : width
 
-    if (allowOverflowBreaks && wordLike && text.length > 1) {
+    if (allowOverflowBreaks && kind === 'text' && text.length > 1) {
       let fitMode: BreakableFitMode = 'sum-graphemes'
       if (letterSpacing !== 0) {
         fitMode = 'segment-prefixes'
@@ -523,7 +522,6 @@ function measureAnalysis(
 
   for (let mi = 0; mi < analysis.len; mi++) {
     const segText = analysis.texts[mi]!
-    const segWordLike = analysis.isWordLike[mi]!
     const segKind = analysis.kinds[mi]!
     const segStart = analysis.starts[mi]!
 
@@ -585,14 +583,13 @@ function measureAnalysis(
           unitMetrics,
           'text',
           segStart + unit.start,
-          segWordLike,
           wordBreak === 'keep-all' || !unitMetrics.containsCJK,
         )
       }
       continue
     }
 
-    pushMeasuredTextSegment(segText, segMetrics, segKind, segStart, segWordLike, true)
+    pushMeasuredTextSegment(segText, segMetrics, segKind, segStart, true)
   }
 
   if (chunkStartSegmentIndex < widths.length) {


### PR DESCRIPTION
Overlong non-word text segments (repeated symbols like `|`, `{`, `]`, `\\`) were not getting grapheme-level overflow breaks because `pushMeasuredTextSegment` gated breakable fit advances on the `wordLike` flag. Symbol runs are not word-like, so they overflowed the container.

## Changes

- Guard is `kind === 'text'` instead of `wordLike`, so any text segment gets grapheme-level overflow breaks when it exceeds available width.
- Drop the unused `wordLike` parameter from `pushMeasuredTextSegment`.
- Regression test: simple `||||` plus mixed `{{{]]]\\|||`.

## Why PR #208 was closed

#208 applied the same `kind === 'text'` fix and tested only `||||`. A longer mixed symbol run still overflowed. This reuses that approach and adds the mixed-symbol case.

Fixes #206