### PR TITLE
docs+test: break:'never' chips stay atomic; demo pre-wrap is not a chip

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ walkRichInlineLineRanges(prepared, 320, range => {
 It is intentionally narrow:
 - raw inline text in, including boundary spaces
 - caller-owned `extraWidth` for pill chrome
-- `break: 'never'` for atomic items like chips and mentions
+- `break: 'never'` for atomic items like chips and mentions — the item always stays on a single line as one fragment. If it does not fit after existing content, it wraps to the next line whole. If it is wider than the container, it overflows but never splits. Items without `break: 'never'` (including those with `extraWidth`) can still split across lines; `extraWidth` reserves space for visual chrome but does not prevent wrapping.
 - `white-space: normal` only
 - not a nested markup tree and not a general CSS inline formatting engine
 
@@ -170,8 +170,8 @@ type RichInlineItem = {
   text: string // raw author text, including leading/trailing collapsible spaces
   font: string // canvas font shorthand for this item
   letterSpacing?: number // extra horizontal spacing between graphemes, in CSS px
-  break?: 'normal' | 'never' // `never` keeps the item atomic, like a chip
-  extraWidth?: number // caller-owned horizontal chrome, e.g. padding + border width
+  break?: 'normal' | 'never' // `never` keeps the item atomic — it always stays on one line as one fragment, never splits. Default is `normal`.
+  extraWidth?: number // caller-owned horizontal chrome, e.g. padding + border width. Does not affect break behavior; use `break: 'never'` if the item should stay whole.
 }
 type RichInlineCursor = {
   itemIndex: number // Which source RichInlineItem this cursor is currently in

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -985,6 +985,101 @@ describe('rich-inline invariants', () => {
       maxLineWidth: Math.max(...widths),
     })
   })
+
+  test('break never chip stays atomic across all widths', () => {
+    const chipFont = '700 12px Test Sans'
+    const chipExtraWidth = 22
+    const chipText = '@maya'
+    const chipItemIndex = 1
+
+    const prepared = prepareRichInline([
+      { text: 'Ship ', font: FONT },
+      { text: chipText, font: chipFont, break: 'never', extraWidth: chipExtraWidth },
+      { text: "'s rich note wraps cleanly here", font: FONT },
+    ])
+
+    const chipNaturalWidth = measureWidth(chipText, chipFont) + chipExtraWidth
+
+    for (const maxWidth of [300, 200, 120, 80, 60, 40, chipNaturalWidth + 1, chipNaturalWidth - 1, 1]) {
+      const chipLineIndices: number[] = []
+
+      walkRichInlineLineRanges(prepared, maxWidth, (line, lineIndex = chipLineIndices.length) => {
+        for (const frag of line.fragments) {
+          if (frag.itemIndex === chipItemIndex) {
+            chipLineIndices.push(lineIndex)
+          }
+        }
+      })
+
+      expect(chipLineIndices.length).toBeLessThanOrEqual(1)
+
+      if (chipLineIndices.length === 1) {
+        const lines: Array<{ fragments: Array<{ itemIndex: number, text: string }> }> = []
+        walkRichInlineLineRanges(prepared, maxWidth, range => {
+          const line = materializeRichInlineLineRange(prepared, range)
+          lines.push({
+            fragments: line.fragments.map(f => ({ itemIndex: f.itemIndex, text: f.text })),
+          })
+        })
+
+        const chipFragments = lines
+          .flatMap(l => l.fragments)
+          .filter(f => f.itemIndex === chipItemIndex)
+        expect(chipFragments).toHaveLength(1)
+        expect(chipFragments[0]!.text).toBe(chipText)
+      }
+    }
+  })
+
+  test('break never chip wider than container stays whole on one line', () => {
+    const chipFont = '700 12px Test Sans'
+    const wideChipText = 'very-long-chip-label-that-overflows'
+    const chipExtraWidth = 22
+    const chipWidth = measureWidth(wideChipText, chipFont) + chipExtraWidth
+    const maxWidth = chipWidth / 2
+
+    const prepared = prepareRichInline([
+      { text: wideChipText, font: chipFont, break: 'never', extraWidth: chipExtraWidth },
+    ])
+
+    const lines: Array<{ fragments: Array<{ itemIndex: number, text: string }> }> = []
+    walkRichInlineLineRanges(prepared, maxWidth, range => {
+      const line = materializeRichInlineLineRange(prepared, range)
+      lines.push({
+        fragments: line.fragments.map(f => ({ itemIndex: f.itemIndex, text: f.text })),
+      })
+    })
+
+    expect(lines).toHaveLength(1)
+    expect(lines[0]!.fragments).toHaveLength(1)
+    expect(lines[0]!.fragments[0]!.text).toBe(wideChipText)
+  })
+
+  test('break never chip wraps to fresh line when it cannot fit after existing content', () => {
+    const chipFont = '700 12px Test Sans'
+    const chipText = '@maya'
+    const chipExtraWidth = 22
+    const chipWidth = measureWidth(chipText, chipFont) + chipExtraWidth
+    const prefixWidth = measureWidth('Ship', FONT)
+    const maxWidth = prefixWidth + chipWidth - 1
+
+    const prepared = prepareRichInline([
+      { text: 'Ship ', font: FONT },
+      { text: chipText, font: chipFont, break: 'never', extraWidth: chipExtraWidth },
+    ])
+
+    const lines: Array<{ fragments: Array<{ itemIndex: number, text: string }> }> = []
+    walkRichInlineLineRanges(prepared, maxWidth, range => {
+      const line = materializeRichInlineLineRange(prepared, range)
+      lines.push({
+        fragments: line.fragments.map(f => ({ itemIndex: f.itemIndex, text: f.text })),
+      })
+    })
+
+    expect(lines).toHaveLength(2)
+    expect(lines[0]!.fragments.every(f => f.itemIndex !== 1)).toBe(true)
+    expect(lines[1]!.fragments.some(f => f.itemIndex === 1 && f.text === chipText)).toBe(true)
+  })
 })
 
 describe('layout invariants', () => {


### PR DESCRIPTION
Fixes https://github.com/chenglou/pretext/issues/203

The `break: 'never'` engine already keeps a chip on one line as one fragment. The demo "pre-wrap chip" is a code span with `break: 'normal'`. It can split. That is not a chip.

This PR does not change layout engine code.

- README + API comments: `break: 'never'` stays whole (wraps as a unit or overflows). `extraWidth` is chrome only.
- Three tests in `src/layout.test.ts`: atomic across widths, overflow stays one fragment, wrap-to-next-line as a whole.

Not in this PR: #202, #210, #212, #214.

Agent claimed `bun test` 120 pass and `bun run check` clean. I did not re-run those here.