### PR TITLE
Bound whitespace and streamed breakpoint searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Rich-inline preparation with long internal whitespace and streaming layout of long hyphenated runs no longer rescan growing portions of the input. Pixel font-size extraction also avoids repeated digit-suffix scans.
+
 - Rich-inline cursors now retain original item indices across empty items, zero-width items can occupy a line, and boundary spaces preserve their font and signed letter spacing. Mutating a visited line no longer changes the walker's continuation.
 - Overlong independent symbol runs can now wrap at grapheme boundaries, with browser-specific punctuation attachment (#208).
 - Numeric minus signs no longer introduce a preferred break before their number, and ASCII hyphens after CJK text stay attached to the preceding character (#213, #215).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -104,3 +104,13 @@ For one-off performance and memory work, start with `bun start` and an isolated,
 - Diff forced-GC heap snapshots for retained memory.
 
 Bun/Node microbenchmarks are useful for quick experiments, but browser behavior needs browser measurements.
+
+For algorithmic changes, scale both source length and the number of segments,
+preferred breaks, forced lines and rich items. Include repeated punctuation,
+Arabic joins, CJK keep-all, long hyphenated URLs and internal whitespace runs.
+Count visited boundaries and submitted Canvas text, with cold caches, before
+relying on timings; doubling an input should not quadruple repeated work.
+Compare complete public outputs and copied/variable-width continuations as well
+as line counts. Keep narrow diagnostic probes outside the maintained browser
+corpus; retain small semantic regressions when a mechanism changes. The history
+and current bounds are recorded in [RESEARCH.md](RESEARCH.md).

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -49,6 +49,12 @@ existing CJK-leading mixed-run rule also precedes generic ASCII opener attachmen
 even when its final scalar is ASCII: Firefox can keep Hangul plus Latin in one
 word segment where other runtimes separate them.
 
+A single URL can contain many preferred hyphen breaks and produce many narrow
+lines. Restarting the preferred-break search at zero for every continuation made
+streaming and aggregate rich layout quadratic in that run's length. Batch walking
+already carries the next boundary; arbitrary continuation cursors now seek within
+the sorted break list without rescanning earlier cuts or adding cursor state.
+
 Desktop Firefox resolves CSS box widths to 1/60px.
 A headed DPR 2 sweep of 241 box widths from 35px through 36px matched
 `Math.round(width * 60) / 60` within 0.00002px, including 35.59375px resolving to
@@ -212,3 +218,46 @@ The remaining Japanese and Chinese differences varied with browser, width, and f
 ### Font Matrices
 
 The first sampled font matrix showed that some differences move when the font changes while other scripts remain stable. Font matrices are therefore most useful after a specific corpus exposes a problem. Running every corpus under every installed font adds cost without identifying the responsible text pattern.
+
+## Algorithmic work and source ownership
+
+The September 2026 history audit found four earlier families of quadratic work:
+reclassifying growing punctuation/Arabic strings and rescanning cleared slots
+(fixed by `30854d7`, `2148b90`, `4cb8b24`, `f0a326d`); CJK/keep-all growing-unit
+merging (`eb3bbbe`, `f0a326d`); measuring every growing Canvas prefix (bounded by
+`fcf9c62`); and searching hard-break chunks from the beginning for every streamed
+line (`2c52171`). The later source-range cleanup `7201ee8` retained these fixes
+with fewer intermediate structures. Experimental duplicates in history are not
+separate shipped incidents.
+
+Three remaining retry scans were found and repaired without changing layout
+semantics:
+
+- Rich boundary trimming used an unanchored trailing-whitespace regex that tried
+  every suffix of a long internal SPACE run followed by content. Two inward
+  source-offset scans now derive leading/trailing presence and slice once; the
+  exact CSS whitespace set and the first collapsed SPACE's style are preserved.
+- Streaming a long hyphenated URL restarted its preferred-break search at zero
+  for every continuation. The sorted boundary array now supports a lower-bound
+  search for arbitrary starts; an already positioned batch cursor returns
+  immediately. There is no additional cursor state or cache.
+- Pixel font-size extraction retried within every digit run when no `px` suffix
+  followed. Starting only at a digit-run boundary preserves the existing first
+  match and fallback while preventing repeated suffix scans.
+
+The whitespace and preferred-break paths dated to `9364741` and `9cf49de`,
+respectively, before the wrapping-boundary/source-identity work. Counted probes
+verify at most input length plus two whitespace boundary checks; a 4,096-hyphen
+URL's streaming search drops from 2,096,128 skipped boundaries to 12,288 binary
+comparisons. Semantic probes preserve complete ranges, text, widths and copied
+cursors, including signed spacing. Timing probes using a numeric Canvas double
+are algorithm diagnosis, not native browser throughput claims.
+
+The Safari prefix-fit policy still caps each segment at 96 graphemes and uses
+pair context beyond that. Count total submitted text as well as Canvas calls:
+a large combining cluster can appear in up to 96 prefixes, a large but bounded
+linear amplification. The cap does not bound the native font shaper's own cost.
+Current merging, bidi passes, chunk walking and materialization probes found no
+other unbounded repeated scan; output materialization still costs the source it
+visits. Shared font/segment caches can accumulate across unique prepared inputs
+until `clearCache()`, which is a separate lifetime concern.

--- a/accuracy/chrome.json
+++ b/accuracy/chrome.json
@@ -1,17 +1,17 @@
 {
-  "generatedAt": "2026-09-05T22:08:56.878Z",
-  "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+  "generatedAt": "2026-09-05T22:16:07.229Z",
+  "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
   "source": {
-    "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+    "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
       "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
       "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-      "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+      "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
       "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-      "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-      "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+      "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+      "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
       "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
     }
   },

--- a/accuracy/firefox.json
+++ b/accuracy/firefox.json
@@ -1,17 +1,17 @@
 {
-  "generatedAt": "2026-09-05T22:08:56.878Z",
-  "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+  "generatedAt": "2026-09-05T22:16:07.229Z",
+  "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
   "source": {
-    "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+    "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
       "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
       "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-      "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+      "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
       "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-      "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-      "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+      "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+      "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
       "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
     }
   },

--- a/accuracy/letter-spacing.json
+++ b/accuracy/letter-spacing.json
@@ -1,17 +1,17 @@
 {
-  "generatedAt": "2026-09-05T22:08:56.878Z",
-  "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+  "generatedAt": "2026-09-05T22:16:07.229Z",
+  "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
   "source": {
-    "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+    "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
       "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
       "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-      "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+      "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
       "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-      "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-      "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+      "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+      "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
       "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
     }
   },

--- a/accuracy/safari.json
+++ b/accuracy/safari.json
@@ -1,17 +1,17 @@
 {
-  "generatedAt": "2026-09-05T22:08:56.878Z",
-  "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+  "generatedAt": "2026-09-05T22:16:07.229Z",
+  "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
   "source": {
-    "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+    "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
       "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
       "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-      "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+      "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
       "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-      "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-      "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+      "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+      "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
       "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
     }
   },

--- a/benchmarks/chrome.json
+++ b/benchmarks/chrome.json
@@ -3,22 +3,22 @@
   "results": [
     {
       "label": "Our library: prepare()",
-      "ms": 10.75,
+      "ms": 8.850000023841858,
       "desc": "One cold 500-text measurement batch"
     },
     {
       "label": "Our library: layout()",
-      "ms": 0.10575000002980232,
+      "ms": 0.0975,
       "desc": "Normalized hot-path throughput per 500-text batch"
     },
     {
       "label": "DOM batch",
-      "ms": 3,
+      "ms": 2.400000035762787,
       "desc": "Single 400→300px batch resize: write all, then read all"
     },
     {
       "label": "DOM interleaved",
-      "ms": 32.45000001788139,
+      "ms": 29.19999998807907,
       "desc": "Single 400→300px batch resize: write + read per div"
     }
   ],
@@ -30,17 +30,17 @@
     },
     {
       "label": "Our library: layoutWithLines()",
-      "ms": 0.0375,
+      "ms": 0.032500000298023225,
       "desc": "60-text shared-corpus batch across widths 180/220/260px; materializes text lines"
     },
     {
       "label": "Our library: walkLineRanges()",
-      "ms": 0.017500001192092895,
+      "ms": 0.017499999701976778,
       "desc": "60-text shared-corpus batch across widths 180/220/260px; line ranges only, no line text strings"
     },
     {
       "label": "Our library: layoutNextLine()",
-      "ms": 0.02750000059604645,
+      "ms": 0.025,
       "desc": "60-text shared-corpus batch across widths 180/220/260px; streaming line-by-line layout"
     }
   ],
@@ -52,61 +52,61 @@
     },
     {
       "label": "Our library: walkRichInlineLineRanges()",
-      "ms": 0.013750000298023224,
+      "ms": 0.0125,
       "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; per-line ranges with fragment ownership, no text strings"
     },
     {
       "label": "Our library: materializeRichInlineLineRange()",
-      "ms": 0.029999999701976775,
+      "ms": 0.026249999552965163,
       "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; range walker plus per-line materialization"
     },
     {
       "label": "Our library: layoutNextRichInlineLineRange() + materializeRichInlineLineRange()",
-      "ms": 0.025,
+      "ms": 0.02250000089406967,
       "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; streaming range walk plus per-line materialization"
     }
   ],
   "richPreWrapResults": [
     {
       "label": "Our library: measureLineStats()",
-      "ms": 0.19750000089406966,
+      "ms": 0.1825000002980232,
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only"
     },
     {
       "label": "Our library: layoutWithLines()",
-      "ms": 0.2800000011920929,
+      "ms": 0.24249999970197678,
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; materializes text lines"
     },
     {
       "label": "Our library: walkLineRanges()",
-      "ms": 0.15249999910593032,
+      "ms": 0.125,
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; line ranges only, no line text strings"
     },
     {
       "label": "Our library: layoutNextLine()",
-      "ms": 0.6,
+      "ms": 0.5224999994039536,
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; streaming line-by-line layout"
     }
   ],
   "richLongResults": [
     {
       "label": "Our library: measureLineStats()",
-      "ms": 1,
+      "ms": 0.91875,
       "desc": "8 Arabic long-form texts across widths 240/300/360px; stats only"
     },
     {
       "label": "Our library: layoutWithLines()",
-      "ms": 3.70375000089407,
+      "ms": 3.4087499998509885,
       "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines"
     },
     {
       "label": "Our library: walkLineRanges()",
-      "ms": 1.5274999998509884,
+      "ms": 1.4025000005960464,
       "desc": "8 Arabic long-form texts across widths 240/300/360px; line ranges only, no line text strings"
     },
     {
       "label": "Our library: layoutNextLine()",
-      "ms": 3.2824999995529653,
+      "ms": 3.0162499994039536,
       "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout"
     }
   ],
@@ -121,10 +121,10 @@
       "breakableSegments": 0,
       "width": 300,
       "lineCount": 193,
-      "analysisMs": 1.300000011920929,
-      "measureMs": 2.599999964237213,
-      "prepareMs": 3.899999976158142,
-      "layoutMs": 0.015
+      "analysisMs": 1.199999988079071,
+      "measureMs": 2.399999976158142,
+      "prepareMs": 3.5,
+      "layoutMs": 0.014000000059604644
     },
     {
       "id": "ja-rashomon",
@@ -136,10 +136,10 @@
       "breakableSegments": 6,
       "width": 300,
       "lineCount": 380,
-      "analysisMs": 2.599999964237213,
-      "measureMs": 4.900000035762787,
-      "prepareMs": 7.400000035762787,
-      "layoutMs": 0.0275
+      "analysisMs": 2.300000011920929,
+      "measureMs": 4.600000023841858,
+      "prepareMs": 7,
+      "layoutMs": 0.02699999988079071
     },
     {
       "id": "ko-unsu-joh-eun-nal",
@@ -151,10 +151,10 @@
       "breakableSegments": 3,
       "width": 300,
       "lineCount": 428,
-      "analysisMs": 1.600000023841858,
-      "measureMs": 4.999999940395355,
-      "prepareMs": 6.800000011920929,
-      "layoutMs": 0.052000000178813933
+      "analysisMs": 1.5,
+      "measureMs": 4.799999952316284,
+      "prepareMs": 6.5,
+      "layoutMs": 0.051500000059604645
     },
     {
       "id": "ko-sonagi",
@@ -167,7 +167,7 @@
       "width": 300,
       "lineCount": 332,
       "analysisMs": 1.199999988079071,
-      "measureMs": 3.8000000715255737,
+      "measureMs": 3.900000035762787,
       "prepareMs": 5,
       "layoutMs": 0.03899999976158142
     },
@@ -181,10 +181,10 @@
       "breakableSegments": 2,
       "width": 300,
       "lineCount": 626,
-      "analysisMs": 3.900000035762787,
-      "measureMs": 8.300000071525574,
-      "prepareMs": 12.100000023841858,
-      "layoutMs": 0.04199999988079071
+      "analysisMs": 3.600000023841858,
+      "measureMs": 7.699999988079071,
+      "prepareMs": 11.300000011920929,
+      "layoutMs": 0.04200000017881393
     },
     {
       "id": "zh-guxiang",
@@ -196,10 +196,10 @@
       "breakableSegments": 14,
       "width": 300,
       "lineCount": 375,
-      "analysisMs": 2.299999952316284,
-      "measureMs": 4.899999976158142,
-      "prepareMs": 7,
-      "layoutMs": 0.025999999940395355
+      "analysisMs": 2.100000023841858,
+      "measureMs": 4.599999964237213,
+      "prepareMs": 6.899999976158142,
+      "layoutMs": 0.025
     },
     {
       "id": "th-nithan-vetal-story-1",
@@ -211,10 +211,10 @@
       "breakableSegments": 8087,
       "width": 300,
       "lineCount": 1024,
-      "analysisMs": 6.699999988079071,
-      "measureMs": 4.799999952316284,
-      "prepareMs": 11.399999976158142,
-      "layoutMs": 0.060500000119209286
+      "analysisMs": 6.300000011920929,
+      "measureMs": 4.200000047683716,
+      "prepareMs": 10.700000047683716,
+      "layoutMs": 0.05700000017881393
     },
     {
       "id": "my-cunning-heron-teacher",
@@ -226,9 +226,9 @@
       "breakableSegments": 424,
       "width": 300,
       "lineCount": 81,
-      "analysisMs": 0.40000003576278687,
-      "measureMs": 0.5999999642372131,
-      "prepareMs": 1.0999999642372131,
+      "analysisMs": 0.5,
+      "measureMs": 0.40000003576278687,
+      "prepareMs": 0.8999999761581421,
       "layoutMs": 0.004000000059604645
     },
     {
@@ -243,7 +243,7 @@
       "lineCount": 54,
       "analysisMs": 0.30000001192092896,
       "measureMs": 0.3999999761581421,
-      "prepareMs": 0.699999988079071,
+      "prepareMs": 0.6000000238418579,
       "layoutMs": 0.0025
     },
     {
@@ -256,10 +256,10 @@
       "breakableSegments": 2917,
       "width": 300,
       "lineCount": 352,
-      "analysisMs": 1.800000011920929,
-      "measureMs": 2.5,
-      "prepareMs": 4.300000011920929,
-      "layoutMs": 0.02550000011920929
+      "analysisMs": 1.699999988079071,
+      "measureMs": 2.5000000596046448,
+      "prepareMs": 4.199999988079071,
+      "layoutMs": 0.025
     },
     {
       "id": "km-prachum-reuang-preng-khmer-volume-7-stories-1-10",
@@ -271,10 +271,10 @@
       "breakableSegments": 3547,
       "width": 300,
       "lineCount": 591,
-      "analysisMs": 3.900000035762787,
-      "measureMs": 3.199999988079071,
-      "prepareMs": 6.899999976158142,
-      "layoutMs": 0.05700000017881393
+      "analysisMs": 3.600000023841858,
+      "measureMs": 3.099999964237213,
+      "prepareMs": 6.799999952316284,
+      "layoutMs": 0.055499999821186065
     },
     {
       "id": "hi-eidgah",
@@ -286,10 +286,10 @@
       "breakableSegments": 4089,
       "width": 300,
       "lineCount": 653,
-      "analysisMs": 2.800000011920929,
-      "measureMs": 5,
-      "prepareMs": 7.800000011920929,
-      "layoutMs": 0.047000000178813936
+      "analysisMs": 2.699999988079071,
+      "measureMs": 4.500000059604645,
+      "prepareMs": 7.100000023841858,
+      "layoutMs": 0.044000000059604645
     },
     {
       "id": "synthetic-long-breakable-runs",
@@ -301,10 +301,10 @@
       "breakableSegments": 1540,
       "width": 300,
       "lineCount": 2860,
-      "analysisMs": 4.100000023841858,
-      "measureMs": 8.300000011920929,
-      "prepareMs": 12.5,
-      "layoutMs": 0.365
+      "analysisMs": 3.5,
+      "measureMs": 7.5,
+      "prepareMs": 11,
+      "layoutMs": 0.2675
     },
     {
       "id": "ar-risalat-al-ghufran-part-1",
@@ -316,10 +316,10 @@
       "breakableSegments": 18756,
       "width": 300,
       "lineCount": 2643,
-      "analysisMs": 16.600000023841858,
-      "measureMs": 27.700000047683716,
-      "prepareMs": 43.69999998807907,
-      "layoutMs": 0.18449999988079072
+      "analysisMs": 13,
+      "measureMs": 23.100000023841858,
+      "prepareMs": 39.30000001192093,
+      "layoutMs": 0.16950000017881395
     }
   ]
 }

--- a/benchmarks/safari.json
+++ b/benchmarks/safari.json
@@ -3,7 +3,7 @@
   "results": [
     {
       "label": "Our library: prepare()",
-      "ms": 10.5,
+      "ms": 11.500000000000057,
       "desc": "One cold 500-text measurement batch"
     },
     {
@@ -13,29 +13,29 @@
     },
     {
       "label": "DOM batch",
-      "ms": 52.99999999999994,
+      "ms": 52,
       "desc": "Single 400→300px batch resize: write all, then read all"
     },
     {
       "label": "DOM interleaved",
-      "ms": 99,
+      "ms": 98,
       "desc": "Single 400→300px batch resize: write + read per div"
     }
   ],
   "richResults": [
     {
       "label": "Our library: measureLineStats()",
-      "ms": 0.02499999999999432,
+      "ms": 0.025,
       "desc": "60-text shared-corpus batch across widths 180/220/260px; stats only"
     },
     {
       "label": "Our library: layoutWithLines()",
-      "ms": 0.0375,
+      "ms": 0.025,
       "desc": "60-text shared-corpus batch across widths 180/220/260px; materializes text lines"
     },
     {
       "label": "Our library: walkLineRanges()",
-      "ms": 0.025,
+      "ms": 0.02499999999999432,
       "desc": "60-text shared-corpus batch across widths 180/220/260px; line ranges only, no line text strings"
     },
     {
@@ -57,7 +57,7 @@
     },
     {
       "label": "Our library: materializeRichInlineLineRange()",
-      "ms": 0.037499999999994316,
+      "ms": 0.025,
       "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; range walker plus per-line materialization"
     },
     {
@@ -69,7 +69,7 @@
   "richPreWrapResults": [
     {
       "label": "Our library: measureLineStats()",
-      "ms": 0.2,
+      "ms": 0.22499999999998865,
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only"
     },
     {
@@ -84,19 +84,19 @@
     },
     {
       "label": "Our library: layoutNextLine()",
-      "ms": 0.4999999999999886,
+      "ms": 0.5,
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; streaming line-by-line layout"
     }
   ],
   "richLongResults": [
     {
       "label": "Our library: measureLineStats()",
-      "ms": 0.925,
+      "ms": 0.9,
       "desc": "8 Arabic long-form texts across widths 240/300/360px; stats only"
     },
     {
       "label": "Our library: layoutWithLines()",
-      "ms": 3.150000000000011,
+      "ms": 3.125,
       "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines"
     },
     {
@@ -106,7 +106,7 @@
     },
     {
       "label": "Our library: layoutNextLine()",
-      "ms": 2.3125000000000115,
+      "ms": 2.3,
       "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout"
     }
   ],
@@ -137,9 +137,9 @@
       "width": 300,
       "lineCount": 380,
       "analysisMs": 2,
-      "measureMs": 4.000000000001819,
-      "prepareMs": 6.9999999999990905,
-      "layoutMs": 0.029999999999995454
+      "measureMs": 5,
+      "prepareMs": 7,
+      "layoutMs": 0.03
     },
     {
       "id": "ko-unsu-joh-eun-nal",
@@ -152,7 +152,7 @@
       "width": 300,
       "lineCount": 428,
       "analysisMs": 2,
-      "measureMs": 6,
+      "measureMs": 5.0000000000009095,
       "prepareMs": 7,
       "layoutMs": 0.055
     },
@@ -169,7 +169,7 @@
       "analysisMs": 1,
       "measureMs": 4,
       "prepareMs": 5,
-      "layoutMs": 0.04
+      "layoutMs": 0.04499999999999545
     },
     {
       "id": "zh-zhufu",
@@ -182,8 +182,8 @@
       "width": 300,
       "lineCount": 626,
       "analysisMs": 4,
-      "measureMs": 9,
-      "prepareMs": 13,
+      "measureMs": 8.00000000000091,
+      "prepareMs": 12,
       "layoutMs": 0.045
     },
     {
@@ -196,10 +196,10 @@
       "breakableSegments": 14,
       "width": 300,
       "lineCount": 375,
-      "analysisMs": 2.0000000000009095,
+      "analysisMs": 2,
       "measureMs": 5.9999999999990905,
       "prepareMs": 8,
-      "layoutMs": 0.025
+      "layoutMs": 0.025000000000004546
     },
     {
       "id": "th-nithan-vetal-story-1",
@@ -212,7 +212,7 @@
       "width": 300,
       "lineCount": 1024,
       "analysisMs": 6,
-      "measureMs": 16,
+      "measureMs": 15.000000000002728,
       "prepareMs": 22,
       "layoutMs": 0.06
     },
@@ -287,8 +287,8 @@
       "width": 300,
       "lineCount": 653,
       "analysisMs": 3,
-      "measureMs": 20,
-      "prepareMs": 22.99999999999818,
+      "measureMs": 19.00000000000182,
+      "prepareMs": 22.00000000000182,
       "layoutMs": 0.055
     },
     {
@@ -302,9 +302,9 @@
       "width": 300,
       "lineCount": 2860,
       "analysisMs": 5,
-      "measureMs": 69,
-      "prepareMs": 74,
-      "layoutMs": 0.35
+      "measureMs": 68.99999999999636,
+      "prepareMs": 73,
+      "layoutMs": 0.3450000000000091
     },
     {
       "id": "ar-risalat-al-ghufran-part-1",
@@ -316,9 +316,9 @@
       "breakableSegments": 18756,
       "width": 300,
       "lineCount": 2644,
-      "analysisMs": 11,
-      "measureMs": 118,
-      "prepareMs": 128,
+      "analysisMs": 10,
+      "measureMs": 114,
+      "prepareMs": 124.00000000000182,
       "layoutMs": 0.21
     }
   ]

--- a/corpora/chrome-step10.json
+++ b/corpora/chrome-step10.json
@@ -1,18 +1,18 @@
 [
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -43,19 +43,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -175,19 +175,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -267,19 +267,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -351,19 +351,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -394,19 +394,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -437,19 +437,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -625,19 +625,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -725,19 +725,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -785,19 +785,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -837,19 +837,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -880,19 +880,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -923,19 +923,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -966,19 +966,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1018,19 +1018,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1061,19 +1061,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1104,19 +1104,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1147,19 +1147,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },

--- a/corpora/dashboard.json
+++ b/corpora/dashboard.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-09-05T22:08:56.915Z",
+  "generatedAt": "2026-09-05T22:16:07.257Z",
   "sources": {
     "accuracy": {
       "chrome": "accuracy/chrome.json",

--- a/corpora/firefox-step10.json
+++ b/corpora/firefox-step10.json
@@ -1,18 +1,18 @@
 [
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -124,19 +124,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -656,19 +656,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -699,19 +699,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -815,19 +815,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -891,19 +891,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -934,19 +934,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -977,19 +977,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1020,19 +1020,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1152,19 +1152,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1268,19 +1268,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1416,19 +1416,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1500,19 +1500,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1568,19 +1568,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1611,19 +1611,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1654,19 +1654,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1754,19 +1754,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1797,19 +1797,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },

--- a/corpora/safari-step10.json
+++ b/corpora/safari-step10.json
@@ -1,18 +1,18 @@
 [
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -43,19 +43,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -111,19 +111,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -154,19 +154,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -197,19 +197,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -240,19 +240,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -283,19 +283,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -326,19 +326,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -369,19 +369,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -412,19 +412,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -455,19 +455,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -523,19 +523,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -583,19 +583,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -626,19 +626,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -678,19 +678,19 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -721,19 +721,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -764,19 +764,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -807,19 +807,19 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:08:56.878Z",
-    "suiteHash": "a3567aaad94c409992fbd828f041c780a16162dba4779837d88a6ec6cd3b9e4d",
+    "generatedAt": "2026-09-05T22:16:07.229Z",
+    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
     "source": {
-      "revision": "76b4b4e270af1c93bdaa9033f27a22438ec3f56c",
+      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
         "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "759c959c9ccad83eda86a0af0220658c90c2cf62b298374c35db5aaebd3872fd",
+        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
-        "measurement.ts": "2b3360a3fceb5cf88482d9cb1c7dc007e14074cfecb50479573bc655faf849bb",
-        "rich-inline.ts": "1c67f7c2f468cf58639e16aef0b47829609500549fe243ad53253e3abe878967",
+        "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
+        "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -556,6 +556,16 @@ describe('boundary-policy regressions', () => {
 })
 
 describe('measurement invariants', () => {
+  test('font-size parsing retains pixel and fallback behavior', async () => {
+    const { parseFontSize: parseCssFontSize } = await import('./measurement.ts')
+    for (const [font, expected] of [
+      ['700 12.5px/1.4 Test Sans', 12.5],
+      ['12.34.56px Test Sans', 34.56],
+      ['12\tpx Test Sans', 12],
+      [`${'1'.repeat(4096)}pt Test Sans`, 16],
+    ] as const) expect(parseCssFontSize(font)).toBe(expected)
+  })
+
   test('breakable fit cache distinguishes fit modes', () => {
     const metrics: SegmentMetrics = { width: 80, containsCJK: false }
     const cache = new Map<string, SegmentMetrics>([
@@ -818,6 +828,21 @@ describe('prepare invariants', () => {
     expect(layoutWithLines(unicodeDash, unicodeWidth, LINE_HEIGHT).lines[0]?.text).toBe('https://alpha\u2010')
   })
 
+  test('resumes around preferred boundaries without reusing consumed hyphens', () => {
+    const text = 'https://a-bc-defgh-ij'
+    for (const letterSpacing of [0, 1]) {
+      const prepared = prepareWithSegments(text, FONT, { letterSpacing })
+      const width = measureWidth('bc-def', FONT) + 6 * letterSpacing + 0.1
+      for (const [graphemeIndex, expected] of [[9, '-bc-'], [10, 'bc-'], [11, 'c-'], [19, 'ij']] as const) {
+        const start = { segmentIndex: 0, graphemeIndex }
+        const line = layoutNextLine(prepared, start, width)!
+        expect(line.text).toBe(expected)
+        const range = layoutNextLineRange(prepared, start, width)!
+        expect(materializeLineRange(prepared, range)).toEqual(line)
+      }
+    }
+  })
+
   test('does not prefer hyphen-like boundaries in keep-all runs', () => {
     const text = 'foo-bar日本語'
     const prepared = prepareWithSegments(text, FONT, { wordBreak: 'keep-all' })
@@ -1053,6 +1078,24 @@ describe('prepare invariants', () => {
 })
 
 describe('rich-inline invariants', () => {
+  test('rich boundary trimming preserves internal spaces and non-collapsible content', () => {
+    for (const boundary of [' ', '\t', '\n', '\f', '\r']) {
+      const prepared = prepareRichInline([
+        { text: `${boundary}A${boundary.repeat(64)}B${boundary}`, font: FONT },
+        { text: '', font: FONT },
+        { text: boundary, font: '32px Test Sans' },
+        { text: '\u00A0C\u00A0', font: FONT },
+      ])
+      const range = layoutNextRichInlineLineRange(prepared, Infinity)!
+      const line = materializeRichInlineLineRange(prepared, range)
+      expect(line.fragments.map(fragment => [fragment.itemIndex, fragment.text])).toEqual([
+        [0, 'A B'], [3, '\u00A0C\u00A0'],
+      ])
+      expect(line.fragments[1]!.gapBefore).toBeCloseTo(measureWidth(' ', FONT), 8)
+      expect(range.end).toEqual({ itemIndex: 4, segmentIndex: 0, graphemeIndex: 0 })
+    }
+  })
+
   test('a whole zero-width rich item fits the end of an exactly filled line', () => {
     const prepared = prepareRichInline([
       { text: 'A', font: FONT },

--- a/src/line-break.ts
+++ b/src/line-break.ts
@@ -167,11 +167,19 @@ function getNextPreferredBreakIndex(
   preferredBreakIndex: number,
   graphemeEnd: number,
 ): number {
-  let index = preferredBreakIndex
-  while (index < preferredBreaks.length && preferredBreaks[index]! < graphemeEnd) {
-    index++
+  let lo = preferredBreakIndex
+  if (lo >= preferredBreaks.length || preferredBreaks[lo]! >= graphemeEnd) return lo
+
+  // Batch walking already carries the next boundary. Public continuation
+  // cursors can start anywhere, so seek instead of rescanning every prior cut.
+  let hi = preferredBreaks.length
+  lo++
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2)
+    if (preferredBreaks[mid]! < graphemeEnd) lo = mid + 1
+    else hi = mid
   }
-  return index
+  return lo
 }
 
 function getTerminalLetterSpacing(

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -112,7 +112,8 @@ export function getEngineProfile(): EngineProfile {
 }
 
 export function parseFontSize(font: string): number {
-  const m = font.match(/(\d+(?:\.\d+)?)\s*px/)
+  // A failed size can restart at the next digit run, not at every digit in it.
+  const m = font.match(/(?:^|\D)(\d+(?:\.\d+)?)\s*px/)
   return m ? parseFloat(m[1]!) : 16
 }
 

--- a/src/rich-inline.ts
+++ b/src/rich-inline.ts
@@ -88,9 +88,6 @@ type PreparedRichInlineItem = {
   prepared: PreparedTextWithSegments
 }
 
-const COLLAPSIBLE_BOUNDARY_RE = /[ \t\n\f\r]+/
-const LEADING_COLLAPSIBLE_BOUNDARY_RE = /^[ \t\n\f\r]+/
-const TRAILING_COLLAPSIBLE_BOUNDARY_RE = /[ \t\n\f\r]+$/
 const EMPTY_LAYOUT_CURSOR: LayoutCursor = { segmentIndex: 0, graphemeIndex: 0 }
 const RICH_INLINE_START_CURSOR: RichInlineCursor = {
   itemIndex: 0,
@@ -111,6 +108,10 @@ function cloneCursor(cursor: LayoutCursor): LayoutCursor {
 
 function isLineStartCursor(cursor: LayoutCursor): boolean {
   return cursor.segmentIndex === 0 && cursor.graphemeIndex === 0
+}
+
+function isCollapsibleBoundaryWhitespace(code: number): boolean {
+  return code === 0x20 || code === 0x09 || code === 0x0A || code === 0x0C || code === 0x0D
 }
 
 function getCollapsedSpaceWidth(font: string, letterSpacing: number): number {
@@ -145,18 +146,23 @@ export function prepareRichInline(items: RichInlineItem[]): PreparedRichInline {
   for (let index = 0; index < items.length; index++) {
     const item = items[index]!
     const letterSpacing = item.letterSpacing ?? 0
-    const hasLeadingWhitespace = LEADING_COLLAPSIBLE_BOUNDARY_RE.test(item.text)
-    const hasTrailingWhitespace = TRAILING_COLLAPSIBLE_BOUNDARY_RE.test(item.text)
-    const trimmedText = item.text
-      .replace(LEADING_COLLAPSIBLE_BOUNDARY_RE, '')
-      .replace(TRAILING_COLLAPSIBLE_BOUNDARY_RE, '')
+    let start = 0
+    while (start < item.text.length && isCollapsibleBoundaryWhitespace(item.text.charCodeAt(start))) start++
 
-    if (trimmedText.length === 0) {
-      if (COLLAPSIBLE_BOUNDARY_RE.test(item.text) && pendingGapWidth === null) {
+    if (start === item.text.length) {
+      if (start > 0 && pendingGapWidth === null) {
         pendingGapWidth = getCollapsedSpaceWidth(item.font, letterSpacing)
       }
       continue
     }
+
+    // Scan from the ends once. A trailing-whitespace regex retries every
+    // position in a long internal space run when later content prevents a match.
+    let end = item.text.length
+    while (end > start && isCollapsibleBoundaryWhitespace(item.text.charCodeAt(end - 1))) end--
+    const hasLeadingWhitespace = start > 0
+    const hasTrailingWhitespace = end < item.text.length
+    const trimmedText = item.text.slice(start, end)
 
     const gapBefore = pendingGapWidth ?? (
       hasLeadingWhitespace ? getCollapsedSpaceWidth(item.font, letterSpacing) : 0

--- a/status/dashboard.json
+++ b/status/dashboard.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-09-05T22:08:56.933Z",
+  "generatedAt": "2026-09-05T22:16:07.274Z",
   "sources": {
     "accuracy": {
       "chrome": "accuracy/chrome.json",
@@ -40,19 +40,19 @@
     "chrome": {
       "topLevel": {
         "Our library: prepare()": {
-          "ms": 10.75,
+          "ms": 8.850000023841858,
           "desc": "One cold 500-text measurement batch"
         },
         "Our library: layout()": {
-          "ms": 0.10575000002980232,
+          "ms": 0.0975,
           "desc": "Normalized hot-path throughput per 500-text batch"
         },
         "DOM batch": {
-          "ms": 3,
+          "ms": 2.400000035762787,
           "desc": "Single 400→300px batch resize: write all, then read all"
         },
         "DOM interleaved": {
-          "ms": 32.45000001788139,
+          "ms": 29.19999998807907,
           "desc": "Single 400→300px batch resize: write + read per div"
         }
       },
@@ -62,15 +62,15 @@
           "desc": "60-text shared-corpus batch across widths 180/220/260px; stats only"
         },
         "Our library: layoutWithLines()": {
-          "ms": 0.0375,
+          "ms": 0.032500000298023225,
           "desc": "60-text shared-corpus batch across widths 180/220/260px; materializes text lines"
         },
         "Our library: walkLineRanges()": {
-          "ms": 0.017500001192092895,
+          "ms": 0.017499999701976778,
           "desc": "60-text shared-corpus batch across widths 180/220/260px; line ranges only, no line text strings"
         },
         "Our library: layoutNextLine()": {
-          "ms": 0.02750000059604645,
+          "ms": 0.025,
           "desc": "60-text shared-corpus batch across widths 180/220/260px; streaming line-by-line layout"
         }
       },
@@ -80,51 +80,51 @@
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; stats only"
         },
         "Our library: walkRichInlineLineRanges()": {
-          "ms": 0.013750000298023224,
+          "ms": 0.0125,
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; per-line ranges with fragment ownership, no text strings"
         },
         "Our library: materializeRichInlineLineRange()": {
-          "ms": 0.029999999701976775,
+          "ms": 0.026249999552965163,
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; range walker plus per-line materialization"
         },
         "Our library: layoutNextRichInlineLineRange() + materializeRichInlineLineRange()": {
-          "ms": 0.025,
+          "ms": 0.02250000089406967,
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; streaming range walk plus per-line materialization"
         }
       },
       "richPreWrap": {
         "Our library: measureLineStats()": {
-          "ms": 0.19750000089406966,
+          "ms": 0.1825000002980232,
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only"
         },
         "Our library: layoutWithLines()": {
-          "ms": 0.2800000011920929,
+          "ms": 0.24249999970197678,
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; materializes text lines"
         },
         "Our library: walkLineRanges()": {
-          "ms": 0.15249999910593032,
+          "ms": 0.125,
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; line ranges only, no line text strings"
         },
         "Our library: layoutNextLine()": {
-          "ms": 0.6,
+          "ms": 0.5224999994039536,
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; streaming line-by-line layout"
         }
       },
       "richLong": {
         "Our library: measureLineStats()": {
-          "ms": 1,
+          "ms": 0.91875,
           "desc": "8 Arabic long-form texts across widths 240/300/360px; stats only"
         },
         "Our library: layoutWithLines()": {
-          "ms": 3.70375000089407,
+          "ms": 3.4087499998509885,
           "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines"
         },
         "Our library: walkLineRanges()": {
-          "ms": 1.5274999998509884,
+          "ms": 1.4025000005960464,
           "desc": "8 Arabic long-form texts across widths 240/300/360px; line ranges only, no line text strings"
         },
         "Our library: layoutNextLine()": {
-          "ms": 3.2824999995529653,
+          "ms": 3.0162499994039536,
           "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout"
         }
       },
@@ -139,10 +139,10 @@
           "breakableSegments": 0,
           "width": 300,
           "lineCount": 193,
-          "analysisMs": 1.300000011920929,
-          "measureMs": 2.599999964237213,
-          "prepareMs": 3.899999976158142,
-          "layoutMs": 0.015
+          "analysisMs": 1.199999988079071,
+          "measureMs": 2.399999976158142,
+          "prepareMs": 3.5,
+          "layoutMs": 0.014000000059604644
         },
         {
           "id": "ja-rashomon",
@@ -154,10 +154,10 @@
           "breakableSegments": 6,
           "width": 300,
           "lineCount": 380,
-          "analysisMs": 2.599999964237213,
-          "measureMs": 4.900000035762787,
-          "prepareMs": 7.400000035762787,
-          "layoutMs": 0.0275
+          "analysisMs": 2.300000011920929,
+          "measureMs": 4.600000023841858,
+          "prepareMs": 7,
+          "layoutMs": 0.02699999988079071
         },
         {
           "id": "ko-unsu-joh-eun-nal",
@@ -169,10 +169,10 @@
           "breakableSegments": 3,
           "width": 300,
           "lineCount": 428,
-          "analysisMs": 1.600000023841858,
-          "measureMs": 4.999999940395355,
-          "prepareMs": 6.800000011920929,
-          "layoutMs": 0.052000000178813933
+          "analysisMs": 1.5,
+          "measureMs": 4.799999952316284,
+          "prepareMs": 6.5,
+          "layoutMs": 0.051500000059604645
         },
         {
           "id": "ko-sonagi",
@@ -185,7 +185,7 @@
           "width": 300,
           "lineCount": 332,
           "analysisMs": 1.199999988079071,
-          "measureMs": 3.8000000715255737,
+          "measureMs": 3.900000035762787,
           "prepareMs": 5,
           "layoutMs": 0.03899999976158142
         },
@@ -199,10 +199,10 @@
           "breakableSegments": 2,
           "width": 300,
           "lineCount": 626,
-          "analysisMs": 3.900000035762787,
-          "measureMs": 8.300000071525574,
-          "prepareMs": 12.100000023841858,
-          "layoutMs": 0.04199999988079071
+          "analysisMs": 3.600000023841858,
+          "measureMs": 7.699999988079071,
+          "prepareMs": 11.300000011920929,
+          "layoutMs": 0.04200000017881393
         },
         {
           "id": "zh-guxiang",
@@ -214,10 +214,10 @@
           "breakableSegments": 14,
           "width": 300,
           "lineCount": 375,
-          "analysisMs": 2.299999952316284,
-          "measureMs": 4.899999976158142,
-          "prepareMs": 7,
-          "layoutMs": 0.025999999940395355
+          "analysisMs": 2.100000023841858,
+          "measureMs": 4.599999964237213,
+          "prepareMs": 6.899999976158142,
+          "layoutMs": 0.025
         },
         {
           "id": "th-nithan-vetal-story-1",
@@ -229,10 +229,10 @@
           "breakableSegments": 8087,
           "width": 300,
           "lineCount": 1024,
-          "analysisMs": 6.699999988079071,
-          "measureMs": 4.799999952316284,
-          "prepareMs": 11.399999976158142,
-          "layoutMs": 0.060500000119209286
+          "analysisMs": 6.300000011920929,
+          "measureMs": 4.200000047683716,
+          "prepareMs": 10.700000047683716,
+          "layoutMs": 0.05700000017881393
         },
         {
           "id": "my-cunning-heron-teacher",
@@ -244,9 +244,9 @@
           "breakableSegments": 424,
           "width": 300,
           "lineCount": 81,
-          "analysisMs": 0.40000003576278687,
-          "measureMs": 0.5999999642372131,
-          "prepareMs": 1.0999999642372131,
+          "analysisMs": 0.5,
+          "measureMs": 0.40000003576278687,
+          "prepareMs": 0.8999999761581421,
           "layoutMs": 0.004000000059604645
         },
         {
@@ -261,7 +261,7 @@
           "lineCount": 54,
           "analysisMs": 0.30000001192092896,
           "measureMs": 0.3999999761581421,
-          "prepareMs": 0.699999988079071,
+          "prepareMs": 0.6000000238418579,
           "layoutMs": 0.0025
         },
         {
@@ -274,10 +274,10 @@
           "breakableSegments": 2917,
           "width": 300,
           "lineCount": 352,
-          "analysisMs": 1.800000011920929,
-          "measureMs": 2.5,
-          "prepareMs": 4.300000011920929,
-          "layoutMs": 0.02550000011920929
+          "analysisMs": 1.699999988079071,
+          "measureMs": 2.5000000596046448,
+          "prepareMs": 4.199999988079071,
+          "layoutMs": 0.025
         },
         {
           "id": "km-prachum-reuang-preng-khmer-volume-7-stories-1-10",
@@ -289,10 +289,10 @@
           "breakableSegments": 3547,
           "width": 300,
           "lineCount": 591,
-          "analysisMs": 3.900000035762787,
-          "measureMs": 3.199999988079071,
-          "prepareMs": 6.899999976158142,
-          "layoutMs": 0.05700000017881393
+          "analysisMs": 3.600000023841858,
+          "measureMs": 3.099999964237213,
+          "prepareMs": 6.799999952316284,
+          "layoutMs": 0.055499999821186065
         },
         {
           "id": "hi-eidgah",
@@ -304,10 +304,10 @@
           "breakableSegments": 4089,
           "width": 300,
           "lineCount": 653,
-          "analysisMs": 2.800000011920929,
-          "measureMs": 5,
-          "prepareMs": 7.800000011920929,
-          "layoutMs": 0.047000000178813936
+          "analysisMs": 2.699999988079071,
+          "measureMs": 4.500000059604645,
+          "prepareMs": 7.100000023841858,
+          "layoutMs": 0.044000000059604645
         },
         {
           "id": "synthetic-long-breakable-runs",
@@ -319,10 +319,10 @@
           "breakableSegments": 1540,
           "width": 300,
           "lineCount": 2860,
-          "analysisMs": 4.100000023841858,
-          "measureMs": 8.300000011920929,
-          "prepareMs": 12.5,
-          "layoutMs": 0.365
+          "analysisMs": 3.5,
+          "measureMs": 7.5,
+          "prepareMs": 11,
+          "layoutMs": 0.2675
         },
         {
           "id": "ar-risalat-al-ghufran-part-1",
@@ -334,17 +334,17 @@
           "breakableSegments": 18756,
           "width": 300,
           "lineCount": 2643,
-          "analysisMs": 16.600000023841858,
-          "measureMs": 27.700000047683716,
-          "prepareMs": 43.69999998807907,
-          "layoutMs": 0.18449999988079072
+          "analysisMs": 13,
+          "measureMs": 23.100000023841858,
+          "prepareMs": 39.30000001192093,
+          "layoutMs": 0.16950000017881395
         }
       ]
     },
     "safari": {
       "topLevel": {
         "Our library: prepare()": {
-          "ms": 10.5,
+          "ms": 11.500000000000057,
           "desc": "One cold 500-text measurement batch"
         },
         "Our library: layout()": {
@@ -352,25 +352,25 @@
           "desc": "Normalized hot-path throughput per 500-text batch"
         },
         "DOM batch": {
-          "ms": 52.99999999999994,
+          "ms": 52,
           "desc": "Single 400→300px batch resize: write all, then read all"
         },
         "DOM interleaved": {
-          "ms": 99,
+          "ms": 98,
           "desc": "Single 400→300px batch resize: write + read per div"
         }
       },
       "richShared": {
         "Our library: measureLineStats()": {
-          "ms": 0.02499999999999432,
+          "ms": 0.025,
           "desc": "60-text shared-corpus batch across widths 180/220/260px; stats only"
         },
         "Our library: layoutWithLines()": {
-          "ms": 0.0375,
+          "ms": 0.025,
           "desc": "60-text shared-corpus batch across widths 180/220/260px; materializes text lines"
         },
         "Our library: walkLineRanges()": {
-          "ms": 0.025,
+          "ms": 0.02499999999999432,
           "desc": "60-text shared-corpus batch across widths 180/220/260px; line ranges only, no line text strings"
         },
         "Our library: layoutNextLine()": {
@@ -388,7 +388,7 @@
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; per-line ranges with fragment ownership, no text strings"
         },
         "Our library: materializeRichInlineLineRange()": {
-          "ms": 0.037499999999994316,
+          "ms": 0.025,
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; range walker plus per-line materialization"
         },
         "Our library: layoutNextRichInlineLineRange() + materializeRichInlineLineRange()": {
@@ -398,7 +398,7 @@
       },
       "richPreWrap": {
         "Our library: measureLineStats()": {
-          "ms": 0.2,
+          "ms": 0.22499999999998865,
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only"
         },
         "Our library: layoutWithLines()": {
@@ -410,17 +410,17 @@
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; line ranges only, no line text strings"
         },
         "Our library: layoutNextLine()": {
-          "ms": 0.4999999999999886,
+          "ms": 0.5,
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; streaming line-by-line layout"
         }
       },
       "richLong": {
         "Our library: measureLineStats()": {
-          "ms": 0.925,
+          "ms": 0.9,
           "desc": "8 Arabic long-form texts across widths 240/300/360px; stats only"
         },
         "Our library: layoutWithLines()": {
-          "ms": 3.150000000000011,
+          "ms": 3.125,
           "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines"
         },
         "Our library: walkLineRanges()": {
@@ -428,7 +428,7 @@
           "desc": "8 Arabic long-form texts across widths 240/300/360px; line ranges only, no line text strings"
         },
         "Our library: layoutNextLine()": {
-          "ms": 2.3125000000000115,
+          "ms": 2.3,
           "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout"
         }
       },
@@ -459,9 +459,9 @@
           "width": 300,
           "lineCount": 380,
           "analysisMs": 2,
-          "measureMs": 4.000000000001819,
-          "prepareMs": 6.9999999999990905,
-          "layoutMs": 0.029999999999995454
+          "measureMs": 5,
+          "prepareMs": 7,
+          "layoutMs": 0.03
         },
         {
           "id": "ko-unsu-joh-eun-nal",
@@ -474,7 +474,7 @@
           "width": 300,
           "lineCount": 428,
           "analysisMs": 2,
-          "measureMs": 6,
+          "measureMs": 5.0000000000009095,
           "prepareMs": 7,
           "layoutMs": 0.055
         },
@@ -491,7 +491,7 @@
           "analysisMs": 1,
           "measureMs": 4,
           "prepareMs": 5,
-          "layoutMs": 0.04
+          "layoutMs": 0.04499999999999545
         },
         {
           "id": "zh-zhufu",
@@ -504,8 +504,8 @@
           "width": 300,
           "lineCount": 626,
           "analysisMs": 4,
-          "measureMs": 9,
-          "prepareMs": 13,
+          "measureMs": 8.00000000000091,
+          "prepareMs": 12,
           "layoutMs": 0.045
         },
         {
@@ -518,10 +518,10 @@
           "breakableSegments": 14,
           "width": 300,
           "lineCount": 375,
-          "analysisMs": 2.0000000000009095,
+          "analysisMs": 2,
           "measureMs": 5.9999999999990905,
           "prepareMs": 8,
-          "layoutMs": 0.025
+          "layoutMs": 0.025000000000004546
         },
         {
           "id": "th-nithan-vetal-story-1",
@@ -534,7 +534,7 @@
           "width": 300,
           "lineCount": 1024,
           "analysisMs": 6,
-          "measureMs": 16,
+          "measureMs": 15.000000000002728,
           "prepareMs": 22,
           "layoutMs": 0.06
         },
@@ -609,8 +609,8 @@
           "width": 300,
           "lineCount": 653,
           "analysisMs": 3,
-          "measureMs": 20,
-          "prepareMs": 22.99999999999818,
+          "measureMs": 19.00000000000182,
+          "prepareMs": 22.00000000000182,
           "layoutMs": 0.055
         },
         {
@@ -624,9 +624,9 @@
           "width": 300,
           "lineCount": 2860,
           "analysisMs": 5,
-          "measureMs": 69,
-          "prepareMs": 74,
-          "layoutMs": 0.35
+          "measureMs": 68.99999999999636,
+          "prepareMs": 73,
+          "layoutMs": 0.3450000000000091
         },
         {
           "id": "ar-risalat-al-ghufran-part-1",
@@ -638,9 +638,9 @@
           "breakableSegments": 18756,
           "width": 300,
           "lineCount": 2644,
-          "analysisMs": 11,
-          "measureMs": 118,
-          "prepareMs": 128,
+          "analysisMs": 10,
+          "measureMs": 114,
+          "prepareMs": 124.00000000000182,
           "layoutMs": 0.21
         }
       ]

--- a/tests/wrapping/VALIDATION.md
+++ b/tests/wrapping/VALIDATION.md
@@ -8,6 +8,50 @@ opposites discovered during review.
 [README.md](README.md) explains the runner; [INVENTORY.md](INVENTORY.md) records
 coverage, provenance and research protocols outside its scope.
 
+## Algorithmic-work audit and repairs
+
+The history/current-code audit repaired three inherited repeated scans:
+rich boundary whitespace, preferred-break lookup for streamed continuations,
+and pixel font-size parsing. Production changes are +30/−15 lines, with no new
+public state or caches. The cause and retained historical bounds are documented
+in [RESEARCH.md](../../RESEARCH.md).
+
+All 33,622 ordinary inputs passed fresh Chrome, Safari and Firefox comparisons
+against reviewed runtime `ac6289f`, both directions. An independent raw-row audit
+confirms every prediction and assessment is identical, with zero required or
+execution failures and no new API/rich failures; all fourteen native rich-item
+height checks pass per browser. Nine numeric environment profiles also agree.
+This is an ordinary comparison, not a new full exploratory sweep. Accuracy,
+spacing and corpus snapshots were regenerated from exactly these observations.
+The baseline remains `ac6289f` because no native correctness result changes.
+
+The smaller structural checks separately count work. Rich endpoint scanning
+uses at most source length plus two checks. The 4,096-hyphen streaming witness
+drops from 2,096,128 skipped cuts to 12,288 binary comparisons. Before/after public
+comparisons cover 21,546 arbitrary cursors, 3,456 width cases, 720 rich cases and
+5,664 whitespace/style range/text/stats comparisons; all agree. Font-parser
+probes retain exact numeric captures on malformed/multi-dot inputs as well as
+normal CSS shorthand. Permanent tests retain three compact semantic regressions;
+final unit/static/package/site checks pass (171 tests, 1,026 assertions).
+
+Foreground Chrome/Safari paired native runs freeze the same baseline/current
+sources, use five balanced ABBA/BAAB rounds, and retain 380 timing samples plus
+eight output-parity checks per browser at visible DPR 2. On Safari, internal
+SPACE runs of 4K/8K/16K take 17.5/66/267 ms before the fix; the new preparation is
+below the 1 ms timer resolution. Chrome already optimizes that regex case, so
+its tiny timings do not establish a useful speedup ratio. For 4,096 URL hyphens,
+copied range streaming changes from 2.41 to 0.37 ms in Chrome and 2.7 to 0.4 ms in
+Safari; stats change from 2.195 to 0.228 ms and 2.525 to 0.3 ms respectively.
+Batch ranges already scale linearly and the small normal preparation canary is
+roughly unchanged. These samples establish the large targeted effects, not
+universal speedups or zero-cost short operations. Both canonical benchmark
+snapshots were refreshed as medians of three foreground runs.
+
+Artifacts: `/private/tmp/pretext-merge-audit-20260905/linear-{chrome,safari,firefox}`,
+`linear-audit.json`, `complexity-native`, `complexity-history.md`,
+`complexity-prepare.md` and `complexity-walking.md`. Suite hash:
+`cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663`. The flat #210/#211 work remains separate.
+
 ## Published-main landing validation
 
 The isolated landing starts at published main `76b4b4e`; unrelated unpublished


### PR DESCRIPTION
Long internal whitespace could make rich-inline preparation quadratic in Safari, and each streamed continuation of a long hyphenated URL rescanned all earlier preferred breaks. Scan whitespace from the ends and binary-search the existing sorted breakpoints while preserving the batch path. Also prevent font-size parsing from retrying every digit suffix. No new public state or caches.

The history audit traced these to older code and verified the earlier punctuation, Arabic, CJK, prefix-measurement and chunk-lookup repairs remain intact. Findings and limits are recorded in RESEARCH.md.

Validation: 33,622 fresh Chrome/Safari/Firefox cases with identical complete predictions and assessments to the accepted implementation; counted work and arbitrary-cursor/whitespace/font-parser equivalence probes; 171 unit tests plus static, package and demo-build checks. Snapshots refreshed.

Balanced foreground benchmarks: Safari’s 16K internal-space case goes from about 267 ms to below its 1 ms timer resolution. At 4,096 hyphens, copied streaming improves roughly 6–7× and stats 8–10× in Chrome/Safari. Batch ranges and the small normal canary remain roughly unchanged.

Flat #210/#211 remains open and unchanged.
