### PR TITLE
Unify complex line layout and retain native extraction evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Streaming line layouts and line statistics now agree with batch layout when a later break follows a soft hyphen. Streaming also retains later text after consecutive lines containing only invisible break controls.
+- Streaming line layouts and line statistics now agree with batch layout when a later break follows a soft hyphen. Streaming also retains later text after consecutive lines containing only invisible break controls (#222).
 
 - Rich-inline preparation with long internal whitespace and streaming layout of long hyphenated runs no longer rescan growing portions of the input. Pixel font-size extraction also avoids repeated digit-suffix scans.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Streaming line layouts and line statistics now agree with batch layout when a later break follows a soft hyphen. Streaming also retains later text after consecutive lines containing only invisible break controls.
+
 - Rich-inline preparation with long internal whitespace and streaming layout of long hyphenated runs no longer rescan growing portions of the input. Pixel font-size extraction also avoids repeated digit-suffix scans.
 
 - Rich-inline cursors now retain original item indices across empty items, zero-width items can occupy a line, and boundary spaces preserve their font and signed letter spacing. Mutating a visited line no longer changes the walker's continuation.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,7 +19,9 @@ See [the wrapping suite](tests/wrapping/README.md) for worktree comparisons,
 known-failure reporting, native observation limits and reproducible case IDs.
 Its default gate requires the maintained absolute checks and rejects lost baseline
 successes elsewhere; it does not claim zero total incompatibilities. The ordinary
-and full schedules use the same assertions.
+and full schedules use the same assertions. Public API comparisons retain every
+serialized line field, including any selected-break metadata, while comparing
+widths with their existing numeric tolerance.
 
 ### Packaging And Release
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -58,6 +58,16 @@ For portable Chrome correctness checks, use `bun run test:wrapping --transport=p
 
 When a probe finds a first-break mismatch, the report includes a short trace. `sN:gM` identifies a segment and grapheme; `[ours]` and `[browser]` identify the competing break positions. Safari `Range` extraction can be wrong around preserved whitespace and URL queries even when the rendered height is correct, so compare `--method=span` before changing the engine.
 
+The shared suite records the original paragraph and the selected extraction as
+separate observations. Normalizing the source or inserting spans can change
+wrapping. Each extraction therefore retains its exact source, method, height,
+resolved line height and all rectangles. Its line count comes from its own height,
+not from grouping source rectangles. Exact boundary checks use only established
+source ownership; ambiguous control or whitespace rectangles stay unobserved.
+Observer v1 captures lack this stage geometry and cannot be retroactively used
+as v2 extraction evidence. Fresh comparisons run both library versions against
+the same observer; changing an observer is not a library accuracy improvement.
+
 ### Corpus Tooling
 
 - `bun run corpus-check` — diagnose one corpus at one or a few widths

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -85,6 +85,32 @@ returning a start. Skipping just one could make a SHY-only chunk terminate the
 paragraph and drop later visible text. Actual empty hard-break chunks still
 produce empty lines; consumed controls are not substitutes for those chunks.
 
+## Original Observations And Resumed Runs
+
+Source cuts, whole-item admission and storage partitions are different facts.
+An original item can span stored SHY/mark pieces; splitting its storage must not
+silently replace the intact observation used to decide whether it fits. A selected
+prefix can also leave a real remaining width that is not determined by the source
+cursor alone. A copied continuation must retain any such history that its model
+needs, rather than reconstructing it from a newly measured suffix.
+
+That does not make arbitrary prefix arithmetic valid. A fresh Safari probe of
+134 restart relationships rejected 61 attempts to splice an original-prefix
+difference onto a freshly measured leading fragment. For Amiri at 16px and zero
+spacing, the inferred width of WJ + acute + b was 12.384px while the direct
+observation was 12.768px. Retaining a whole-item remainder and constructing a new
+partial measurement are different operations. The observation's exact source
+span and shaping context must remain attached to it.
+
+A Unicode count of spacing owners is insufficient too: WJ can advance source
+without owning an extra spacing slot, while WJ with a combining mark changes its
+advance with the original glyph context. Requested-spacing Canvas observations
+resolve some of those cases but disagree with native optional-ligature behavior
+in opposing inputs. Neither a blanket owner count nor a blanket Canvas-spacing
+replacement is accepted. Measuring every possible resumed substring is outside
+the intended bounded preparation model. The broader source-boundary prototype
+therefore remains experimental; these findings do not establish a flat #210 fix.
+
 ## Rich Inline Source Identity And Boundary Spaces
 
 A rich item has source identity independently of its measured width. Filtering

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -51,9 +51,12 @@ word segment where other runtimes separate them.
 
 A single URL can contain many preferred hyphen breaks and produce many narrow
 lines. Restarting the preferred-break search at zero for every continuation made
-streaming and aggregate rich layout quadratic in that run's length. Batch walking
-already carries the next boundary; arbitrary continuation cursors now seek within
+streaming and aggregate rich layout quadratic in that run's length. The simple batch walk
+carries the next boundary; arbitrary continuation cursors seek within
 the sorted break list without rescanning earlier cuts or adding cursor state.
+The shared complex batch walker currently uses those bounded searches per line,
+so its preferred-cut lookup work is O(lines × log(cuts)), not the simple walker’s
+carried-index bound.
 
 Desktop Firefox resolves CSS box widths to 1/60px.
 A headed DPR 2 sweep of 241 box widths from 35px through 36px matched
@@ -63,6 +66,24 @@ independent signed-spacing and ligature thresholds in the full sweep. Box
 resolution does not establish the inline fit threshold, so the line walkers
 retain their existing width handling. Wider Unicode-affix tailoring likewise
 exposed inherited trailing-space admission failures; it remains unmodeled here.
+
+## One Decision For Complex Line Layout
+
+The complex batch and streaming walkers used different priorities after SHY.
+When a later hanging boundary fit, streaming could rewind to an earlier SHY
+while batch layout consumed the later boundary. The source and geometry were
+already available; duplicating the decision algorithm caused the disagreement.
+Complex batch and streaming layout now use one scan loop with the batch
+priority; streaming stops after one line. Scratch values and helpers belong to
+the whole walk, while ordinary text retains its simple fast path. In the full native
+comparison, this preserves every batch line and browser-accuracy result and
+removes the API disagreements in all three browsers. Exact source partition
+diagnostics remain separate from allowed suppressed-control boundary gaps.
+
+Line-start normalization must cross every consecutive consumed-only chunk before
+returning a start. Skipping just one could make a SHY-only chunk terminate the
+paragraph and drop later visible text. Actual empty hard-break chunks still
+produce empty lines; consumed controls are not substitutes for those chunks.
 
 ## Rich Inline Source Identity And Boundary Spaces
 

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -111,6 +111,39 @@ replacement is accepted. Measuring every possible resumed substring is outside
 the intended bounded preparation model. The broader source-boundary prototype
 therefore remains experimental; these findings do not establish a flat #210 fix.
 
+A separate lossless source-coordinate compiler preserves complete paragraph
+output and reconstructs tested returned cursors from normalized source offsets.
+It must retain measurement-local boundaries: global grapheme segmentation is
+not an equivalent partition. The prototype still lowers into the accepted
+walker, so it establishes representational freedom without establishing a
+simpler algorithm or a native accuracy improvement. Its additional adapter has
+not earned production cost.
+
+## Native Line Extraction Is An Observation
+
+Grouping each grapheme by its first Range rectangle can undercount real lines.
+In three narrow Safari control/combining-mark witnesses, the paragraph height
+and whole Range expose six lines while first-rectangle grouping exposes five.
+A zero-width rectangle on the previous line can precede the actual next-line
+rectangle. Choosing the first positive rectangle is insufficient too: Chrome
+can give the letter after SHY positive rectangles on both the selected hyphen's
+line and the letter's own line.
+
+Extraction also changes the object being observed. A separate 230-input probe
+in each of Chrome and Safari found that inserting grapheme spans changed native
+line counts on two Chrome and ten Safari inputs. Normalizing the source changed
+counts too. Text-node Range, span intervention and original paragraph geometry
+must remain separate; none may silently borrow another stage's height.
+
+The shared observer now retains each selected extraction's source, method,
+height, resolved line height, grapheme fragments and scalar Range rectangles.
+The measured line-box count survives even when source ownership is ambiguous.
+Scalar rectangles come from that same extraction DOM, since a mixed grapheme's
+box does not locate each of its scalars. Known visible mismatches remain failures;
+rectangle order or positivity alone does not establish invisible ownership.
+This is test instrumentation only. The production library still performs no DOM
+measurement, and these findings do not solve missing shaping information.
+
 ## Rich Inline Source Identity And Boundary Spaces
 
 A rich item has source identity independently of its measured width. Filtering

--- a/accuracy/chrome.json
+++ b/accuracy/chrome.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-09-06T10:15:09.247Z",
-  "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+  "generatedAt": "2026-09-06T11:09:43.297Z",
+  "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
   "source": {
-    "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+    "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -26,7 +26,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": true,
+      "focused": false,
       "fonts": []
     }
   ],

--- a/accuracy/chrome.json
+++ b/accuracy/chrome.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-09-06T10:00:12.191Z",
-  "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+  "generatedAt": "2026-09-06T10:15:09.247Z",
+  "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
   "source": {
-    "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+    "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -26,7 +26,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": false,
+      "focused": true,
       "fonts": []
     }
   ],

--- a/accuracy/chrome.json
+++ b/accuracy/chrome.json
@@ -1,14 +1,14 @@
 {
-  "generatedAt": "2026-09-05T22:16:07.229Z",
-  "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+  "generatedAt": "2026-09-06T10:00:12.191Z",
+  "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
   "source": {
-    "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+    "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
       "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-      "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-      "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+      "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+      "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
       "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
       "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
       "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",

--- a/accuracy/firefox.json
+++ b/accuracy/firefox.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-09-06T10:15:09.247Z",
-  "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+  "generatedAt": "2026-09-06T11:09:43.297Z",
+  "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
   "source": {
-    "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+    "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",

--- a/accuracy/firefox.json
+++ b/accuracy/firefox.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-09-06T10:00:12.191Z",
-  "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+  "generatedAt": "2026-09-06T10:15:09.247Z",
+  "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
   "source": {
-    "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+    "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",

--- a/accuracy/firefox.json
+++ b/accuracy/firefox.json
@@ -1,14 +1,14 @@
 {
-  "generatedAt": "2026-09-05T22:16:07.229Z",
-  "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+  "generatedAt": "2026-09-06T10:00:12.191Z",
+  "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
   "source": {
-    "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+    "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
       "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-      "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-      "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+      "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+      "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
       "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
       "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
       "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",

--- a/accuracy/letter-spacing.json
+++ b/accuracy/letter-spacing.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-09-06T10:15:09.247Z",
-  "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+  "generatedAt": "2026-09-06T11:09:43.297Z",
+  "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
   "source": {
-    "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+    "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -27,7 +27,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": true,
+      "focused": false,
       "fonts": []
     },
     {
@@ -41,7 +41,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": true,
+      "focused": false,
       "fonts": []
     },
     {
@@ -55,7 +55,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": true,
+      "focused": false,
       "fonts": []
     },
     {
@@ -69,7 +69,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": true,
+      "focused": false,
       "fonts": []
     },
     {
@@ -83,7 +83,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": true,
+      "focused": false,
       "fonts": []
     },
     {
@@ -160,7 +160,7 @@
   "total": 28,
   "geometryMatchCount": 28,
   "geometryMismatchCount": 0,
-  "firstBreakMismatchCount": 7,
+  "firstBreakMismatchCount": 0,
   "results": [
     {
       "browser": "chrome",
@@ -340,7 +340,7 @@
       "predicted": 96,
       "diff": 0,
       "pass": true,
-      "breaks": "fail"
+      "breaks": "unobserved"
     },
     {
       "browser": "chrome",
@@ -466,7 +466,7 @@
       "predicted": 128,
       "diff": 0,
       "pass": true,
-      "breaks": "fail"
+      "breaks": "pass"
     },
     {
       "browser": "safari",
@@ -520,7 +520,7 @@
       "predicted": 102,
       "diff": 0,
       "pass": true,
-      "breaks": "fail"
+      "breaks": "pass"
     },
     {
       "browser": "safari",
@@ -556,7 +556,7 @@
       "predicted": 64,
       "diff": 0,
       "pass": true,
-      "breaks": "fail"
+      "breaks": "pass"
     },
     {
       "browser": "safari",
@@ -592,7 +592,7 @@
       "predicted": 96,
       "diff": 0,
       "pass": true,
-      "breaks": "fail"
+      "breaks": "unobserved"
     },
     {
       "browser": "safari",
@@ -628,7 +628,7 @@
       "predicted": 64,
       "diff": 0,
       "pass": true,
-      "breaks": "fail"
+      "breaks": "pass"
     },
     {
       "browser": "safari",
@@ -646,7 +646,7 @@
       "predicted": 68,
       "diff": 0,
       "pass": true,
-      "breaks": "fail"
+      "breaks": "pass"
     },
     {
       "browser": "safari",

--- a/accuracy/letter-spacing.json
+++ b/accuracy/letter-spacing.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-09-06T10:00:12.191Z",
-  "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+  "generatedAt": "2026-09-06T10:15:09.247Z",
+  "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
   "source": {
-    "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+    "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -27,7 +27,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": false,
+      "focused": true,
       "fonts": []
     },
     {
@@ -41,7 +41,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": false,
+      "focused": true,
       "fonts": []
     },
     {
@@ -55,7 +55,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": false,
+      "focused": true,
       "fonts": []
     },
     {
@@ -69,7 +69,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": false,
+      "focused": true,
       "fonts": []
     },
     {
@@ -83,7 +83,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": false,
+      "focused": true,
       "fonts": []
     },
     {

--- a/accuracy/letter-spacing.json
+++ b/accuracy/letter-spacing.json
@@ -1,14 +1,14 @@
 {
-  "generatedAt": "2026-09-05T22:16:07.229Z",
-  "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+  "generatedAt": "2026-09-06T10:00:12.191Z",
+  "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
   "source": {
-    "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+    "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
       "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-      "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-      "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+      "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+      "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
       "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
       "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
       "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",

--- a/accuracy/safari.json
+++ b/accuracy/safari.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-09-06T10:15:09.247Z",
-  "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+  "generatedAt": "2026-09-06T11:09:43.297Z",
+  "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
   "source": {
-    "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+    "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",

--- a/accuracy/safari.json
+++ b/accuracy/safari.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-09-06T10:00:12.191Z",
-  "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+  "generatedAt": "2026-09-06T10:15:09.247Z",
+  "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
   "source": {
-    "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+    "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",

--- a/accuracy/safari.json
+++ b/accuracy/safari.json
@@ -1,14 +1,14 @@
 {
-  "generatedAt": "2026-09-05T22:16:07.229Z",
-  "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+  "generatedAt": "2026-09-06T10:00:12.191Z",
+  "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
   "source": {
-    "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+    "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
     "files": {
       "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
       "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
       "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-      "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-      "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+      "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+      "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
       "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
       "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
       "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",

--- a/benchmarks/chrome.json
+++ b/benchmarks/chrome.json
@@ -3,22 +3,22 @@
   "results": [
     {
       "label": "Our library: prepare()",
-      "ms": 8.850000023841858,
+      "ms": 9,
       "desc": "One cold 500-text measurement batch"
     },
     {
       "label": "Our library: layout()",
-      "ms": 0.0975,
+      "ms": 0.08700000002980232,
       "desc": "Normalized hot-path throughput per 500-text batch"
     },
     {
       "label": "DOM batch",
-      "ms": 2.400000035762787,
+      "ms": 2.449999988079071,
       "desc": "Single 400→300px batch resize: write all, then read all"
     },
     {
       "label": "DOM interleaved",
-      "ms": 29.19999998807907,
+      "ms": 29.200000017881393,
       "desc": "Single 400→300px batch resize: write + read per div"
     }
   ],
@@ -35,19 +35,19 @@
     },
     {
       "label": "Our library: walkLineRanges()",
-      "ms": 0.017499999701976778,
+      "ms": 0.013749999552965166,
       "desc": "60-text shared-corpus batch across widths 180/220/260px; line ranges only, no line text strings"
     },
     {
       "label": "Our library: layoutNextLine()",
-      "ms": 0.025,
+      "ms": 0.027499999850988388,
       "desc": "60-text shared-corpus batch across widths 180/220/260px; streaming line-by-line layout"
     }
   ],
   "richInlineResults": [
     {
       "label": "Our library: measureRichInlineStats()",
-      "ms": 0.007500000298023224,
+      "ms": 0.007499999552965164,
       "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; stats only"
     },
     {
@@ -57,56 +57,56 @@
     },
     {
       "label": "Our library: materializeRichInlineLineRange()",
-      "ms": 0.026249999552965163,
+      "ms": 0.026250000298023227,
       "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; range walker plus per-line materialization"
     },
     {
       "label": "Our library: layoutNextRichInlineLineRange() + materializeRichInlineLineRange()",
-      "ms": 0.02250000089406967,
+      "ms": 0.02250000014901161,
       "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; streaming range walk plus per-line materialization"
     }
   ],
   "richPreWrapResults": [
     {
       "label": "Our library: measureLineStats()",
-      "ms": 0.1825000002980232,
+      "ms": 0.13500000089406966,
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only"
     },
     {
       "label": "Our library: layoutWithLines()",
-      "ms": 0.24249999970197678,
+      "ms": 0.2674999997019768,
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; materializes text lines"
     },
     {
       "label": "Our library: walkLineRanges()",
-      "ms": 0.125,
+      "ms": 0.14500000029802323,
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; line ranges only, no line text strings"
     },
     {
       "label": "Our library: layoutNextLine()",
-      "ms": 0.5224999994039536,
+      "ms": 0.5699999988079071,
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; streaming line-by-line layout"
     }
   ],
   "richLongResults": [
     {
       "label": "Our library: measureLineStats()",
-      "ms": 0.91875,
+      "ms": 0.9012499995529653,
       "desc": "8 Arabic long-form texts across widths 240/300/360px; stats only"
     },
     {
       "label": "Our library: layoutWithLines()",
-      "ms": 3.4087499998509885,
+      "ms": 3.39375,
       "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines"
     },
     {
       "label": "Our library: walkLineRanges()",
-      "ms": 1.4025000005960464,
+      "ms": 1.4024999998509884,
       "desc": "8 Arabic long-form texts across widths 240/300/360px; line ranges only, no line text strings"
     },
     {
       "label": "Our library: layoutNextLine()",
-      "ms": 3.0162499994039536,
+      "ms": 3.012500000745058,
       "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout"
     }
   ],
@@ -121,9 +121,9 @@
       "breakableSegments": 0,
       "width": 300,
       "lineCount": 193,
-      "analysisMs": 1.199999988079071,
-      "measureMs": 2.399999976158142,
-      "prepareMs": 3.5,
+      "analysisMs": 1.100000023841858,
+      "measureMs": 2.300000011920929,
+      "prepareMs": 3.400000035762787,
       "layoutMs": 0.014000000059604644
     },
     {
@@ -137,8 +137,8 @@
       "width": 300,
       "lineCount": 380,
       "analysisMs": 2.300000011920929,
-      "measureMs": 4.600000023841858,
-      "prepareMs": 7,
+      "measureMs": 4.5,
+      "prepareMs": 6.900000035762787,
       "layoutMs": 0.02699999988079071
     },
     {
@@ -152,9 +152,9 @@
       "width": 300,
       "lineCount": 428,
       "analysisMs": 1.5,
-      "measureMs": 4.799999952316284,
-      "prepareMs": 6.5,
-      "layoutMs": 0.051500000059604645
+      "measureMs": 4.700000047683716,
+      "prepareMs": 6.300000011920929,
+      "layoutMs": 0.0525
     },
     {
       "id": "ko-sonagi",
@@ -167,9 +167,9 @@
       "width": 300,
       "lineCount": 332,
       "analysisMs": 1.199999988079071,
-      "measureMs": 3.900000035762787,
-      "prepareMs": 5,
-      "layoutMs": 0.03899999976158142
+      "measureMs": 3.5,
+      "prepareMs": 4.699999988079071,
+      "layoutMs": 0.03900000005960465
     },
     {
       "id": "zh-zhufu",
@@ -181,10 +181,10 @@
       "breakableSegments": 2,
       "width": 300,
       "lineCount": 626,
-      "analysisMs": 3.600000023841858,
-      "measureMs": 7.699999988079071,
-      "prepareMs": 11.300000011920929,
-      "layoutMs": 0.04200000017881393
+      "analysisMs": 3.699999988079071,
+      "measureMs": 7.800000011920929,
+      "prepareMs": 11.5,
+      "layoutMs": 0.0425
     },
     {
       "id": "zh-guxiang",
@@ -196,10 +196,10 @@
       "breakableSegments": 14,
       "width": 300,
       "lineCount": 375,
-      "analysisMs": 2.100000023841858,
+      "analysisMs": 2.199999988079071,
       "measureMs": 4.599999964237213,
-      "prepareMs": 6.899999976158142,
-      "layoutMs": 0.025
+      "prepareMs": 6.800000011920929,
+      "layoutMs": 0.025499999821186066
     },
     {
       "id": "th-nithan-vetal-story-1",
@@ -211,10 +211,10 @@
       "breakableSegments": 8087,
       "width": 300,
       "lineCount": 1024,
-      "analysisMs": 6.300000011920929,
-      "measureMs": 4.200000047683716,
-      "prepareMs": 10.700000047683716,
-      "layoutMs": 0.05700000017881393
+      "analysisMs": 6.400000035762787,
+      "measureMs": 4.199999928474426,
+      "prepareMs": 10.600000023841858,
+      "layoutMs": 0.05650000005960464
     },
     {
       "id": "my-cunning-heron-teacher",
@@ -227,8 +227,8 @@
       "width": 300,
       "lineCount": 81,
       "analysisMs": 0.5,
-      "measureMs": 0.40000003576278687,
-      "prepareMs": 0.8999999761581421,
+      "measureMs": 0.5,
+      "prepareMs": 1,
       "layoutMs": 0.004000000059604645
     },
     {
@@ -242,7 +242,7 @@
       "width": 300,
       "lineCount": 54,
       "analysisMs": 0.30000001192092896,
-      "measureMs": 0.3999999761581421,
+      "measureMs": 0.30000007152557373,
       "prepareMs": 0.6000000238418579,
       "layoutMs": 0.0025
     },
@@ -256,9 +256,9 @@
       "breakableSegments": 2917,
       "width": 300,
       "lineCount": 352,
-      "analysisMs": 1.699999988079071,
-      "measureMs": 2.5000000596046448,
-      "prepareMs": 4.199999988079071,
+      "analysisMs": 1.7999999523162842,
+      "measureMs": 2.300000011920929,
+      "prepareMs": 4.100000023841858,
       "layoutMs": 0.025
     },
     {
@@ -271,10 +271,10 @@
       "breakableSegments": 3547,
       "width": 300,
       "lineCount": 591,
-      "analysisMs": 3.600000023841858,
-      "measureMs": 3.099999964237213,
-      "prepareMs": 6.799999952316284,
-      "layoutMs": 0.055499999821186065
+      "analysisMs": 3.5,
+      "measureMs": 3.299999952316284,
+      "prepareMs": 6.699999988079071,
+      "layoutMs": 0.055999999940395354
     },
     {
       "id": "hi-eidgah",
@@ -286,10 +286,10 @@
       "breakableSegments": 4089,
       "width": 300,
       "lineCount": 653,
-      "analysisMs": 2.699999988079071,
-      "measureMs": 4.500000059604645,
-      "prepareMs": 7.100000023841858,
-      "layoutMs": 0.044000000059604645
+      "analysisMs": 2.600000023841858,
+      "measureMs": 4.5,
+      "prepareMs": 7.099999964237213,
+      "layoutMs": 0.04399999976158142
     },
     {
       "id": "synthetic-long-breakable-runs",
@@ -302,9 +302,9 @@
       "width": 300,
       "lineCount": 2860,
       "analysisMs": 3.5,
-      "measureMs": 7.5,
-      "prepareMs": 11,
-      "layoutMs": 0.2675
+      "measureMs": 7.100000083446503,
+      "prepareMs": 10.699999988079071,
+      "layoutMs": 0.2740000000596046
     },
     {
       "id": "ar-risalat-al-ghufran-part-1",
@@ -316,10 +316,10 @@
       "breakableSegments": 18756,
       "width": 300,
       "lineCount": 2643,
-      "analysisMs": 13,
-      "measureMs": 23.100000023841858,
-      "prepareMs": 39.30000001192093,
-      "layoutMs": 0.16950000017881395
+      "analysisMs": 12.400000035762787,
+      "measureMs": 23.799999952316284,
+      "prepareMs": 35.89999997615814,
+      "layoutMs": 0.17099999994039536
     }
   ]
 }

--- a/benchmarks/safari.json
+++ b/benchmarks/safari.json
@@ -3,7 +3,7 @@
   "results": [
     {
       "label": "Our library: prepare()",
-      "ms": 11.500000000000057,
+      "ms": 11.500000000000028,
       "desc": "One cold 500-text measurement batch"
     },
     {
@@ -13,7 +13,7 @@
     },
     {
       "label": "DOM batch",
-      "ms": 52,
+      "ms": 53,
       "desc": "Single 400→300px batch resize: write all, then read all"
     },
     {
@@ -25,12 +25,12 @@
   "richResults": [
     {
       "label": "Our library: measureLineStats()",
-      "ms": 0.025,
+      "ms": 0.02499999999999432,
       "desc": "60-text shared-corpus batch across widths 180/220/260px; stats only"
     },
     {
       "label": "Our library: layoutWithLines()",
-      "ms": 0.025,
+      "ms": 0.025000000000005684,
       "desc": "60-text shared-corpus batch across widths 180/220/260px; materializes text lines"
     },
     {
@@ -57,7 +57,7 @@
     },
     {
       "label": "Our library: materializeRichInlineLineRange()",
-      "ms": 0.025,
+      "ms": 0.037500000000000006,
       "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; range walker plus per-line materialization"
     },
     {
@@ -69,7 +69,7 @@
   "richPreWrapResults": [
     {
       "label": "Our library: measureLineStats()",
-      "ms": 0.22499999999998865,
+      "ms": 0.15,
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only"
     },
     {
@@ -79,7 +79,7 @@
     },
     {
       "label": "Our library: walkLineRanges()",
-      "ms": 0.15,
+      "ms": 0.2,
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; line ranges only, no line text strings"
     },
     {
@@ -96,17 +96,17 @@
     },
     {
       "label": "Our library: layoutWithLines()",
-      "ms": 3.125,
+      "ms": 3.1,
       "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines"
     },
     {
       "label": "Our library: walkLineRanges()",
-      "ms": 1.75,
+      "ms": 1.7250000000000114,
       "desc": "8 Arabic long-form texts across widths 240/300/360px; line ranges only, no line text strings"
     },
     {
       "label": "Our library: layoutNextLine()",
-      "ms": 2.3,
+      "ms": 2.275,
       "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout"
     }
   ],
@@ -137,8 +137,8 @@
       "width": 300,
       "lineCount": 380,
       "analysisMs": 2,
-      "measureMs": 5,
-      "prepareMs": 7,
+      "measureMs": 4,
+      "prepareMs": 6,
       "layoutMs": 0.03
     },
     {
@@ -153,7 +153,7 @@
       "lineCount": 428,
       "analysisMs": 2,
       "measureMs": 5.0000000000009095,
-      "prepareMs": 7,
+      "prepareMs": 6.9999999999990905,
       "layoutMs": 0.055
     },
     {
@@ -169,7 +169,7 @@
       "analysisMs": 1,
       "measureMs": 4,
       "prepareMs": 5,
-      "layoutMs": 0.04499999999999545
+      "layoutMs": 0.04
     },
     {
       "id": "zh-zhufu",
@@ -182,8 +182,8 @@
       "width": 300,
       "lineCount": 626,
       "analysisMs": 4,
-      "measureMs": 8.00000000000091,
-      "prepareMs": 12,
+      "measureMs": 9.00000000000091,
+      "prepareMs": 13,
       "layoutMs": 0.045
     },
     {
@@ -197,8 +197,8 @@
       "width": 300,
       "lineCount": 375,
       "analysisMs": 2,
-      "measureMs": 5.9999999999990905,
-      "prepareMs": 8,
+      "measureMs": 4.999999999998181,
+      "prepareMs": 7,
       "layoutMs": 0.025000000000004546
     },
     {
@@ -212,7 +212,7 @@
       "width": 300,
       "lineCount": 1024,
       "analysisMs": 6,
-      "measureMs": 15.000000000002728,
+      "measureMs": 15.99999999999909,
       "prepareMs": 22,
       "layoutMs": 0.06
     },
@@ -226,8 +226,8 @@
       "breakableSegments": 424,
       "width": 300,
       "lineCount": 81,
-      "analysisMs": 0.999999999998181,
-      "measureMs": 2.000000000001819,
+      "analysisMs": 0,
+      "measureMs": 3,
       "prepareMs": 3,
       "layoutMs": 0.005
     },
@@ -256,7 +256,7 @@
       "breakableSegments": 2917,
       "width": 300,
       "lineCount": 352,
-      "analysisMs": 2,
+      "analysisMs": 1.999999999998181,
       "measureMs": 30,
       "prepareMs": 32,
       "layoutMs": 0.035
@@ -287,8 +287,8 @@
       "width": 300,
       "lineCount": 653,
       "analysisMs": 3,
-      "measureMs": 19.00000000000182,
-      "prepareMs": 22.00000000000182,
+      "measureMs": 20,
+      "prepareMs": 23,
       "layoutMs": 0.055
     },
     {
@@ -301,10 +301,10 @@
       "breakableSegments": 1540,
       "width": 300,
       "lineCount": 2860,
-      "analysisMs": 5,
-      "measureMs": 68.99999999999636,
-      "prepareMs": 73,
-      "layoutMs": 0.3450000000000091
+      "analysisMs": 4.999999999998181,
+      "measureMs": 67.00000000000364,
+      "prepareMs": 72.00000000000182,
+      "layoutMs": 0.35
     },
     {
       "id": "ar-risalat-al-ghufran-part-1",
@@ -316,10 +316,10 @@
       "breakableSegments": 18756,
       "width": 300,
       "lineCount": 2644,
-      "analysisMs": 10,
-      "measureMs": 114,
-      "prepareMs": 124.00000000000182,
-      "layoutMs": 0.21
+      "analysisMs": 10.000000000001819,
+      "measureMs": 116,
+      "prepareMs": 126,
+      "layoutMs": 0.20999999999999092
     }
   ]
 }

--- a/corpora/chrome-step10.json
+++ b/corpora/chrome-step10.json
@@ -1,15 +1,15 @@
 [
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -43,16 +43,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -175,16 +175,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -267,16 +267,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -351,16 +351,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -394,16 +394,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -437,16 +437,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -625,16 +625,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -725,16 +725,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -785,16 +785,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -837,16 +837,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -880,16 +880,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -923,16 +923,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -966,16 +966,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -1018,16 +1018,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -1061,16 +1061,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -1104,16 +1104,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -1147,16 +1147,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",

--- a/corpora/chrome-step10.json
+++ b/corpora/chrome-step10.json
@@ -1,9 +1,9 @@
 [
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -27,7 +27,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -43,10 +43,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -70,7 +70,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -175,10 +175,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -202,7 +202,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -267,10 +267,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -294,7 +294,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -351,10 +351,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -378,7 +378,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -394,10 +394,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -421,7 +421,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -437,10 +437,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -464,7 +464,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -625,10 +625,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -652,7 +652,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -725,10 +725,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -752,7 +752,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -785,10 +785,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -812,7 +812,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -837,10 +837,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -864,7 +864,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -880,10 +880,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -907,7 +907,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -923,10 +923,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -950,7 +950,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -966,10 +966,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -993,7 +993,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -1018,10 +1018,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1045,7 +1045,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -1061,10 +1061,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1088,7 +1088,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -1104,10 +1104,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1131,7 +1131,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -1147,10 +1147,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1174,7 +1174,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],

--- a/corpora/chrome-step10.json
+++ b/corpora/chrome-step10.json
@@ -1,9 +1,9 @@
 [
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -27,7 +27,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -43,10 +43,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -70,7 +70,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -175,10 +175,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -202,7 +202,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -267,10 +267,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -294,7 +294,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -351,10 +351,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -378,7 +378,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -394,10 +394,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -421,7 +421,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -437,10 +437,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -464,7 +464,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -625,10 +625,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -652,7 +652,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -725,10 +725,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -752,7 +752,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -785,10 +785,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -812,7 +812,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -837,10 +837,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -864,7 +864,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -880,10 +880,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -907,7 +907,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -923,10 +923,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -950,7 +950,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -966,10 +966,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -993,7 +993,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -1018,10 +1018,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1045,7 +1045,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -1061,10 +1061,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1088,7 +1088,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -1104,10 +1104,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1131,7 +1131,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],
@@ -1147,10 +1147,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1174,7 +1174,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": true,
+        "focused": false,
         "fonts": []
       }
     ],

--- a/corpora/dashboard.json
+++ b/corpora/dashboard.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-09-06T10:00:12.222Z",
+  "generatedAt": "2026-09-06T10:15:09.274Z",
   "sources": {
     "accuracy": {
       "chrome": "accuracy/chrome.json",

--- a/corpora/dashboard.json
+++ b/corpora/dashboard.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-09-06T10:15:09.274Z",
+  "generatedAt": "2026-09-06T11:10:40.246Z",
   "sources": {
     "accuracy": {
       "chrome": "accuracy/chrome.json",

--- a/corpora/dashboard.json
+++ b/corpora/dashboard.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-09-05T22:16:07.257Z",
+  "generatedAt": "2026-09-06T10:00:12.222Z",
   "sources": {
     "accuracy": {
       "chrome": "accuracy/chrome.json",

--- a/corpora/firefox-step10.json
+++ b/corpora/firefox-step10.json
@@ -1,15 +1,15 @@
 [
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -124,16 +124,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -656,16 +656,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -699,16 +699,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -815,16 +815,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -891,16 +891,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -934,16 +934,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -977,16 +977,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -1020,16 +1020,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -1152,16 +1152,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -1268,16 +1268,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -1416,16 +1416,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -1500,16 +1500,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -1568,16 +1568,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -1611,16 +1611,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -1654,16 +1654,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -1754,16 +1754,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -1797,16 +1797,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",

--- a/corpora/firefox-step10.json
+++ b/corpora/firefox-step10.json
@@ -1,9 +1,9 @@
 [
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -124,10 +124,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -656,10 +656,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -699,10 +699,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -815,10 +815,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -891,10 +891,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -934,10 +934,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -977,10 +977,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1020,10 +1020,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1152,10 +1152,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1268,10 +1268,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1416,10 +1416,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1500,10 +1500,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1568,10 +1568,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1611,10 +1611,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1654,10 +1654,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1754,10 +1754,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1797,10 +1797,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",

--- a/corpora/firefox-step10.json
+++ b/corpora/firefox-step10.json
@@ -1,9 +1,9 @@
 [
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -124,10 +124,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -656,10 +656,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -699,10 +699,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -815,10 +815,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -891,10 +891,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -934,10 +934,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -977,10 +977,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1020,10 +1020,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1152,10 +1152,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1268,10 +1268,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1416,10 +1416,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1500,10 +1500,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1568,10 +1568,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1611,10 +1611,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1654,10 +1654,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1754,10 +1754,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -1797,10 +1797,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",

--- a/corpora/safari-step10.json
+++ b/corpora/safari-step10.json
@@ -1,15 +1,15 @@
 [
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -43,16 +43,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -111,16 +111,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -154,16 +154,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -197,16 +197,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -240,16 +240,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -283,16 +283,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -326,16 +326,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -369,16 +369,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -412,16 +412,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -455,16 +455,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -523,16 +523,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -583,16 +583,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -626,16 +626,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -678,16 +678,16 @@
     ]
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -721,16 +721,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -764,16 +764,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",
@@ -807,16 +807,16 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-05T22:16:07.229Z",
-    "suiteHash": "cbf597257a39205e6591cc804762b5b61743e513bdaeb388e669feacde7dd663",
+    "generatedAt": "2026-09-06T10:00:12.191Z",
+    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
     "source": {
-      "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
+      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
         "generated/bidi-data.ts": "745211b804d907af78afb6c1ed87eff6d7454a5e85152a6129eb7b3bf0f6f262",
-        "layout.ts": "4cbd10c697940243beaec2c311e6f3978163caa8e204a1d7693fffeda31e2abf",
-        "line-break.ts": "ab5ed48fd374ff3227ed6cf7d916ace75c49b671e6dfc25637f1b835beb83a74",
+        "layout.ts": "6d3c40ecb50fd098e3a3f5114dd98c0630e0b0f5e40f3816a9793a352455ff8b",
+        "line-break.ts": "f226213c179d65adea48b849040719349c8c3928519348d03d38b7b41f344796",
         "line-text.ts": "86058e13259ab1280e1eeea3fe739a40e2f00ddec2b76b4a0d09b1d62f3ea7e1",
         "measurement.ts": "351f601f8a507b230ecf895569eb97da46b8ed480dc91a4f6457fa17c6185187",
         "rich-inline.ts": "5a7e5d339e1f703d52928913e3b7d6a5f5df04bdfdd365f47c1890dde3b61964",

--- a/corpora/safari-step10.json
+++ b/corpora/safari-step10.json
@@ -1,9 +1,9 @@
 [
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -43,10 +43,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -111,10 +111,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -154,10 +154,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -197,10 +197,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -240,10 +240,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -283,10 +283,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -326,10 +326,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -369,10 +369,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -412,10 +412,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -455,10 +455,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -523,10 +523,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -583,10 +583,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -626,10 +626,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -678,10 +678,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -721,10 +721,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -764,10 +764,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -807,10 +807,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:00:12.191Z",
-    "suiteHash": "0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f",
+    "generatedAt": "2026-09-06T10:15:09.247Z",
+    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
     "source": {
-      "revision": "cdc34f13ebb6cbf7511d568b98d4ed98a6e05c68",
+      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",

--- a/corpora/safari-step10.json
+++ b/corpora/safari-step10.json
@@ -1,9 +1,9 @@
 [
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -43,10 +43,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -111,10 +111,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -154,10 +154,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -197,10 +197,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -240,10 +240,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -283,10 +283,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -326,10 +326,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -369,10 +369,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -412,10 +412,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -455,10 +455,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -523,10 +523,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -583,10 +583,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -626,10 +626,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -678,10 +678,10 @@
     ]
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -721,10 +721,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -764,10 +764,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",
@@ -807,10 +807,10 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-06T10:15:09.247Z",
-    "suiteHash": "c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa",
+    "generatedAt": "2026-09-06T11:09:43.297Z",
+    "suiteHash": "0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51",
     "source": {
-      "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+      "revision": "d5810efd14aa9ba9fd2b10b990abb58bbf2faab0",
       "files": {
         "analysis.ts": "b129a4890a7d171f5ae112c5473f941fab38376c178f2b23a3da7f2878dba647",
         "bidi.ts": "c5962b925739049f7d03d8b6f2144a0f84d9e6b26f9900bc0d3f0b92dc20eb51",

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -392,6 +392,24 @@ describe('shared public contracts', () => {
     expect(result.contracts).toEqual([])
   })
 
+  test('public contracts detect lost line metadata even when text and cursors agree', async () => {
+    const api = await import('./layout.ts')
+    const inconsistent = createVariant('inconsistent-line-metadata', {
+      ...api,
+      layoutWithLines(...args: Parameters<typeof api.layoutWithLines>) {
+        const result = api.layoutWithLines(...args)
+        return { ...result, lines: result.lines.map(line => ({ ...line, selectedMarker: null })) }
+      },
+    })
+    const result = inconsistent.predict({
+      id: 'unit-line-metadata', family: 'api', origins: ['maintained'], scope: 'supported',
+      text: 'a\nb', whiteSpace: 'pre-wrap', font: FONT, width: 64, lineHeight: LINE_HEIGHT,
+      wordBreak: 'normal', letterSpacing: 0, direction: 'ltr',
+    })
+    if (result.detail !== 'full') throw new Error('Expected full public contract checks')
+    expect(result.contracts.some(failure => failure.contract === 'fixed-stream/fixed-stream')).toBe(true)
+  })
+
   test('maintained height observations retain the rich prepare/layout route', async () => {
     const api = await import('./layout.ts')
     const richHandles = new WeakSet<object>()
@@ -1794,6 +1812,20 @@ describe('layout invariants', () => {
     expect(layout(prepared, width, LINE_HEIGHT).lineCount).toBe(expected.lineCount)
   })
 
+  test('streaming keeps a later hanging break after an unselected soft hyphen', () => {
+    const width = measureWidth('a-', FONT) + 0.1
+    const prepared = prepareWithSegments('a\u00AD\tb', FONT, { whiteSpace: 'pre-wrap' })
+    const result = variant.predict({
+      id: 'unit-shy-hanging-break', family: 'api', origins: ['maintained'], scope: 'supported',
+      text: 'a\u00AD\tb', whiteSpace: 'pre-wrap', font: FONT, width, lineHeight: LINE_HEIGHT,
+      wordBreak: 'normal', letterSpacing: 0, direction: 'ltr',
+    })
+    if (result.detail !== 'full') throw new Error('Expected full public contract checks')
+    expect(result.lines.map(line => line.text)).toEqual(['a\t', 'b'])
+    expect(result.contracts).toEqual([])
+    expect(collectStreamedLines(prepared, width)).toEqual(layoutWithLines(prepared, width, LINE_HEIGHT).lines)
+  })
+
   test('pre-wrap mode keeps empty lines from consecutive hard breaks', () => {
     const prepared = prepareWithSegments('\n\n', FONT, { whiteSpace: 'pre-wrap' })
     const lines = layoutWithLines(prepared, 200, LINE_HEIGHT)
@@ -1804,6 +1836,29 @@ describe('layout invariants', () => {
     const mixedLines = layoutWithLines(mixed, 200, LINE_HEIGHT)
     expect(mixedLines.lines.map(line => line.text)).toEqual(['中文', '', '世界'])
     expect(collectStreamedLines(mixed, 200)).toEqual(mixedLines.lines)
+  })
+
+  test('consecutive consumed-only chunks retain the visible tail and real empty lines', () => {
+    for (const control of ['\u00AD', '\u200B']) for (const prefix of ['', 'a\n']) for (const emptyLine of ['', '\n']) {
+      const prepared = prepareWithSegments(prefix + control + '\n' + control + '\n' + emptyLine + 'b', FONT, { whiteSpace: 'pre-wrap' })
+      const expected = [...(prefix ? ['a'] : []), ...(emptyLine ? [''] : []), 'b']
+      const batch = layoutWithLines(prepared, 100, LINE_HEIGHT)
+      expect(batch.lines.map(line => line.text)).toEqual(expected)
+      expect(layout(prepared, 100, LINE_HEIGHT).lineCount).toBe(expected.length)
+      expect(measureLineStats(prepared, 100).lineCount).toBe(expected.length)
+      const ranges: NonNullable<ReturnType<LayoutModule['layoutNextLineRange']>>[] = []
+      walkLineRanges(prepared, 100, line => ranges.push(line))
+      const streamed: NonNullable<ReturnType<LayoutModule['layoutNextLineRange']>>[] = []
+      let cursor = { segmentIndex: 0, graphemeIndex: 0 }
+      for (let lineIndex = 0; lineIndex <= expected.length; lineIndex++) {
+        const line = layoutNextLineRange(prepared, JSON.parse(JSON.stringify(cursor)) as typeof cursor, 100)
+        if (line === null) break
+        streamed.push(line)
+        cursor = JSON.parse(JSON.stringify(line.end)) as typeof cursor
+      }
+      expect(streamed).toEqual(ranges)
+      expect(streamed.map(line => materializeLineRange(prepared, line).text)).toEqual(expected)
+    }
   })
 
   test('pre-wrap mode does not invent an extra trailing empty line', () => {

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -504,7 +504,7 @@ function getInternalPrepared(prepared: PreparedText): InternalPreparedText {
 
 // Layout prepared text at a given max width and caller-provided lineHeight.
 // Pure arithmetic on cached widths — no canvas calls, no DOM reads, no string
-// operations, no allocations.
+// operations, and no per-line allocations.
 // ~0.0002ms per text block. Call on every resize.
 //
 // Line breaking rules (matching CSS white-space: normal + overflow-wrap: break-word):

--- a/src/line-break.ts
+++ b/src/line-break.ts
@@ -170,8 +170,8 @@ function getNextPreferredBreakIndex(
   let lo = preferredBreakIndex
   if (lo >= preferredBreaks.length || preferredBreaks[lo]! >= graphemeEnd) return lo
 
-  // Batch walking already carries the next boundary. Public continuation
-  // cursors can start anywhere, so seek instead of rescanning every prior cut.
+  // Simple batch walking carries the next boundary. The shared complex loop
+  // and public continuations seek instead of rescanning every prior cut.
   let hi = preferredBreaks.length
   lo++
   while (lo < hi) {
@@ -256,25 +256,31 @@ function normalizeLineStartInChunk(
   let segmentIndex = cursor.segmentIndex
   if (cursor.graphemeIndex > 0) return chunkIndex
 
-  const chunk = prepared.chunks[chunkIndex]!
-  if (chunk.startSegmentIndex === chunk.endSegmentIndex && segmentIndex === chunk.startSegmentIndex) {
+  // Consumed-only chunks can occur consecutively. Normalize through each of
+  // them before entering the walker, while keeping actual empty hard-break
+  // chunks observable as empty lines.
+  for (let currentChunkIndex = chunkIndex; currentChunkIndex < prepared.chunks.length; currentChunkIndex++) {
+    const chunk = prepared.chunks[currentChunkIndex]!
+    if (chunk.startSegmentIndex === chunk.endSegmentIndex && segmentIndex === chunk.startSegmentIndex) {
+      cursor.segmentIndex = segmentIndex
+      cursor.graphemeIndex = 0
+      return currentChunkIndex
+    }
+
+    if (segmentIndex < chunk.startSegmentIndex) segmentIndex = chunk.startSegmentIndex
+    segmentIndex = normalizeLineStartSegmentIndex(prepared, segmentIndex, chunk.endSegmentIndex)
+    if (segmentIndex < chunk.endSegmentIndex) {
+      cursor.segmentIndex = segmentIndex
+      cursor.graphemeIndex = 0
+      return currentChunkIndex
+    }
+
+    if (chunk.consumedEndSegmentIndex >= prepared.widths.length) return -1
+    segmentIndex = chunk.consumedEndSegmentIndex
     cursor.segmentIndex = segmentIndex
     cursor.graphemeIndex = 0
-    return chunkIndex
   }
-
-  if (segmentIndex < chunk.startSegmentIndex) segmentIndex = chunk.startSegmentIndex
-  segmentIndex = normalizeLineStartSegmentIndex(prepared, segmentIndex, chunk.endSegmentIndex)
-  if (segmentIndex < chunk.endSegmentIndex) {
-    cursor.segmentIndex = segmentIndex
-    cursor.graphemeIndex = 0
-    return chunkIndex
-  }
-
-  if (chunk.consumedEndSegmentIndex >= prepared.widths.length) return -1
-  cursor.segmentIndex = chunk.consumedEndSegmentIndex
-  cursor.graphemeIndex = 0
-  return chunkIndex + 1
+  return -1
 }
 
 // Mutates `cursor` to the next renderable line start and returns its chunk index.
@@ -505,294 +511,10 @@ export function walkPreparedLinesRaw(
   maxWidth: number,
   onLine?: InternalLineVisitor,
 ): number {
-  if (prepared.simpleLineWalkFastPath) {
-    return walkPreparedLinesSimple(prepared, maxWidth, onLine)
-  }
-
-  const {
-    widths,
-    kinds,
-    breakableFitAdvances,
-    breakablePreferredBreaks,
-    discretionaryHyphenWidth,
-    chunks,
-  } = prepared
-  if (widths.length === 0 || chunks.length === 0) return 0
-
-  const engineProfile = getEngineProfile()
-  const lineFitEpsilon = engineProfile.lineFitEpsilon
-  const fitLimit = maxWidth + lineFitEpsilon
-
-  let lineCount = 0
-  let lineW = 0
-  let hasContent = false
-  let lineStartSegmentIndex = 0
-  let lineStartGraphemeIndex = 0
-  let lineEndSegmentIndex = 0
-  let lineEndGraphemeIndex = 0
-  let pendingBreakSegmentIndex = -1
-  let pendingBreakFitWidth = 0
-  let pendingBreakPaintWidth = 0
-  let pendingBreakKind: SegmentBreakKind | null = null
-
-  function clearPendingBreak(): void {
-    pendingBreakSegmentIndex = -1
-    pendingBreakFitWidth = 0
-    pendingBreakPaintWidth = 0
-    pendingBreakKind = null
-  }
-
-  function getCurrentLinePaintWidth(): number {
-    return (
-      pendingBreakKind === 'soft-hyphen' &&
-      pendingBreakSegmentIndex === lineEndSegmentIndex &&
-      lineEndGraphemeIndex === 0
-    )
-      ? pendingBreakPaintWidth
-      : lineW
-  }
-
-  function emitCurrentLine(
-    endSegmentIndex = lineEndSegmentIndex,
-    endGraphemeIndex = lineEndGraphemeIndex,
-    width?: number,
-  ): void {
-    lineCount++
-    if (onLine !== undefined) {
-      onLine(
-        finalizeLinePaintWidth(
-          prepared,
-          width ?? getCurrentLinePaintWidth(),
-          lineStartSegmentIndex,
-          lineStartGraphemeIndex,
-          endSegmentIndex,
-          endGraphemeIndex,
-        ),
-        lineStartSegmentIndex,
-        lineStartGraphemeIndex,
-        endSegmentIndex,
-        endGraphemeIndex,
-      )
-    }
-    lineW = 0
-    hasContent = false
-    clearPendingBreak()
-  }
-
-  function startLineAtSegment(segmentIndex: number, width: number): void {
-    hasContent = true
-    lineStartSegmentIndex = segmentIndex
-    lineStartGraphemeIndex = 0
-    lineEndSegmentIndex = segmentIndex + 1
-    lineEndGraphemeIndex = 0
-    lineW = width
-  }
-
-  function startLineAtGrapheme(segmentIndex: number, graphemeIndex: number, width: number): void {
-    hasContent = true
-    lineStartSegmentIndex = segmentIndex
-    lineStartGraphemeIndex = graphemeIndex
-    lineEndSegmentIndex = segmentIndex
-    lineEndGraphemeIndex = graphemeIndex + 1
-    lineW = width
-  }
-
-  function appendWholeSegment(segmentIndex: number, advance: number): void {
-    if (!hasContent) {
-      startLineAtSegment(segmentIndex, advance)
-      return
-    }
-    lineW += advance
-    lineEndSegmentIndex = segmentIndex + 1
-    lineEndGraphemeIndex = 0
-  }
-
-  function updatePendingBreakForWholeSegment(
-    kind: SegmentBreakKind,
-    breakAfter: boolean,
-    segmentIndex: number,
-    segmentWidth: number,
-    leadingSpacing: number,
-    advance: number,
-  ): void {
-    if (!breakAfter) return
-    const fitAdvance = getBreakOpportunityFitContribution(prepared, kind, segmentIndex, leadingSpacing)
-    const paintAdvance = getLineEndPaintContribution(prepared, kind, segmentIndex, leadingSpacing, segmentWidth)
-    pendingBreakSegmentIndex = segmentIndex + 1
-    pendingBreakFitWidth = lineW - advance + fitAdvance
-    pendingBreakPaintWidth = lineW - advance + paintAdvance
-    pendingBreakKind = kind
-  }
-
-  function appendBreakableSegmentFrom(segmentIndex: number, startGraphemeIndex: number): void {
-    const fitAdvances = breakableFitAdvances[segmentIndex]!
-    const preferredBreaks = breakablePreferredBreaks[segmentIndex] ?? null
-    let preferredBreakIndex = preferredBreaks === null
-      ? -1
-      : getNextPreferredBreakIndex(preferredBreaks, 0, startGraphemeIndex + 1)
-    let lastPreferredBreakEnd = -1
-    let lastPreferredBreakWidth = 0
-
-    let g = startGraphemeIndex
-    while (g < fitAdvances.length) {
-      const baseGw = fitAdvances[g]!
-
-      if (!hasContent) {
-        startLineAtGrapheme(segmentIndex, g, baseGw)
-      } else {
-        const gw = getBreakableGraphemeAdvance(prepared, true, baseGw)
-        const candidatePaintWidth = lineW + gw
-        if (getBreakableCandidateFitWidth(prepared, candidatePaintWidth) > fitLimit) {
-          if (preferredBreaks !== null && lastPreferredBreakEnd > startGraphemeIndex) {
-            emitCurrentLine(segmentIndex, lastPreferredBreakEnd, lastPreferredBreakWidth)
-            g = lastPreferredBreakEnd
-            preferredBreakIndex = getNextPreferredBreakIndex(preferredBreaks, preferredBreakIndex, g + 1)
-            lastPreferredBreakEnd = -1
-            lastPreferredBreakWidth = 0
-            continue
-          }
-          emitCurrentLine()
-          startLineAtGrapheme(segmentIndex, g, baseGw)
-        } else {
-          lineW = candidatePaintWidth
-          lineEndSegmentIndex = segmentIndex
-          lineEndGraphemeIndex = g + 1
-        }
-      }
-
-      const graphemeEnd = g + 1
-      if (preferredBreaks !== null && preferredBreaks[preferredBreakIndex] === graphemeEnd) {
-        lastPreferredBreakEnd = graphemeEnd
-        lastPreferredBreakWidth = lineW
-        preferredBreakIndex++
-      }
-      g++
-    }
-
-    if (hasContent && lineEndSegmentIndex === segmentIndex && lineEndGraphemeIndex === fitAdvances.length) {
-      lineEndSegmentIndex = segmentIndex + 1
-      lineEndGraphemeIndex = 0
-    }
-  }
-
-  function emitEmptyChunk(chunk: { startSegmentIndex: number, consumedEndSegmentIndex: number }): void {
-    lineCount++
-    onLine?.(0, chunk.startSegmentIndex, 0, chunk.consumedEndSegmentIndex, 0)
-    clearPendingBreak()
-  }
-
-  for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
-    const chunk = chunks[chunkIndex]!
-    if (chunk.startSegmentIndex === chunk.endSegmentIndex) {
-      emitEmptyChunk(chunk)
-      continue
-    }
-
-    hasContent = false
-    lineW = 0
-    lineStartSegmentIndex = chunk.startSegmentIndex
-    lineStartGraphemeIndex = 0
-    lineEndSegmentIndex = chunk.startSegmentIndex
-    lineEndGraphemeIndex = 0
-    clearPendingBreak()
-
-    let i = chunk.startSegmentIndex
-    while (i < chunk.endSegmentIndex) {
-      if (!hasContent) {
-        i = normalizeLineStartSegmentIndex(prepared, i, chunk.endSegmentIndex)
-        if (i >= chunk.endSegmentIndex) break
-      }
-
-      const kind = kinds[i]!
-      const breakAfter = breaksAfter(kind)
-      const leadingSpacing = getLeadingLetterSpacing(prepared, hasContent, i)
-      const w = kind === 'tab'
-        ? getTabAdvance(lineW + leadingSpacing, prepared.tabStopAdvance)
-        : widths[i]!
-      const advance = leadingSpacing + w
-      const fitAdvance = getWholeSegmentFitContribution(prepared, kind, i, leadingSpacing, w)
-
-      if (kind === 'soft-hyphen') {
-        if (hasContent) {
-          lineEndSegmentIndex = i + 1
-          lineEndGraphemeIndex = 0
-          // A chunk-ending SHY has no following content to wrap onto another line.
-          if (i + 1 < chunk.endSegmentIndex) {
-            pendingBreakSegmentIndex = i + 1
-            pendingBreakFitWidth = lineW + discretionaryHyphenWidth
-            pendingBreakPaintWidth = lineW + discretionaryHyphenWidth
-            pendingBreakKind = kind
-          }
-        }
-        i++
-        continue
-      }
-
-      if (!hasContent) {
-        if (fitAdvance > fitLimit && breakableFitAdvances[i] !== null) {
-          appendBreakableSegmentFrom(i, 0)
-        } else {
-          startLineAtSegment(i, w)
-        }
-        updatePendingBreakForWholeSegment(kind, breakAfter, i, w, leadingSpacing, advance)
-        i++
-        continue
-      }
-
-      const newFitW = lineW + fitAdvance
-      if (newFitW > fitLimit) {
-        const currentBreakFitWidth =
-          lineW + getBreakOpportunityFitContribution(prepared, kind, i, leadingSpacing)
-        const currentBreakPaintWidth =
-          lineW + getLineEndPaintContribution(prepared, kind, i, leadingSpacing, w)
-
-        if (breakAfter && currentBreakFitWidth <= fitLimit) {
-          appendWholeSegment(i, advance)
-          emitCurrentLine(i + 1, 0, currentBreakPaintWidth)
-          i++
-          continue
-        }
-
-        if (pendingBreakSegmentIndex >= 0 && pendingBreakFitWidth <= fitLimit) {
-          if (
-            lineEndSegmentIndex > pendingBreakSegmentIndex ||
-            (lineEndSegmentIndex === pendingBreakSegmentIndex && lineEndGraphemeIndex > 0)
-          ) {
-            emitCurrentLine()
-            continue
-          }
-          const nextSegmentIndex = pendingBreakSegmentIndex
-          emitCurrentLine(nextSegmentIndex, 0, pendingBreakPaintWidth)
-          i = nextSegmentIndex
-          continue
-        }
-
-        if (fitAdvance > fitLimit && breakableFitAdvances[i] !== null) {
-          emitCurrentLine()
-          appendBreakableSegmentFrom(i, 0)
-          i++
-          continue
-        }
-
-        emitCurrentLine()
-        continue
-      }
-
-      appendWholeSegment(i, advance)
-      updatePendingBreakForWholeSegment(kind, breakAfter, i, w, leadingSpacing, advance)
-      i++
-    }
-
-    if (hasContent) {
-      const finalPaintWidth =
-        pendingBreakSegmentIndex === chunk.consumedEndSegmentIndex
-          ? pendingBreakPaintWidth
-          : lineW
-      emitCurrentLine(chunk.consumedEndSegmentIndex, 0, finalPaintWidth)
-    }
-  }
-
-  return lineCount
+  if (prepared.simpleLineWalkFastPath) return walkPreparedLinesSimple(prepared, maxWidth, onLine)
+  const cursor: LineBreakCursor = { segmentIndex: 0, graphemeIndex: 0 }
+  const chunkIndex = normalizePreparedLineStart(prepared, cursor)
+  return walkPreparedComplexLines(prepared, cursor, chunkIndex, maxWidth, onLine).lineCount
 }
 
 function stepPreparedChunkLineGeometry(
@@ -801,13 +523,17 @@ function stepPreparedChunkLineGeometry(
   chunkIndex: number,
   maxWidth: number,
 ): number | null {
-  const chunk = prepared.chunks[chunkIndex]!
-  if (chunk.startSegmentIndex === chunk.endSegmentIndex) {
-    cursor.segmentIndex = chunk.consumedEndSegmentIndex
-    cursor.graphemeIndex = 0
-    return 0
-  }
+  return walkPreparedComplexLines(prepared, cursor, chunkIndex, maxWidth, undefined, 1).lastLineWidth
+}
 
+function walkPreparedComplexLines(
+  prepared: PreparedLineBreakData,
+  cursor: LineBreakCursor,
+  chunkIndex: number,
+  maxWidth: number,
+  onLine?: InternalLineVisitor,
+  lineLimit = Number.POSITIVE_INFINITY,
+): { lineCount: number; lastLineWidth: number | null } {
   const {
     widths,
     kinds,
@@ -819,16 +545,16 @@ function stepPreparedChunkLineGeometry(
   const lineFitEpsilon = engineProfile.lineFitEpsilon
   const fitLimit = maxWidth + lineFitEpsilon
 
-  const lineStartSegmentIndex = cursor.segmentIndex
-  const lineStartGraphemeIndex = cursor.graphemeIndex
-  let lineW = 0
-  let hasContent = false
-  let lineEndSegmentIndex = cursor.segmentIndex
-  let lineEndGraphemeIndex = cursor.graphemeIndex
-  let pendingBreakSegmentIndex = -1
-  let pendingBreakFitWidth = 0
-  let pendingBreakPaintWidth = 0
-  let pendingBreakKind: SegmentBreakKind | null = null
+  let lineStartSegmentIndex: number
+  let lineStartGraphemeIndex: number
+  let lineW: number
+  let hasContent: boolean
+  let lineEndSegmentIndex: number
+  let lineEndGraphemeIndex: number
+  let pendingBreakSegmentIndex: number
+  let pendingBreakFitWidth: number
+  let pendingBreakPaintWidth: number
+  let pendingBreakKind: SegmentBreakKind | null
 
   function getCurrentLinePaintWidth(): number {
     return (
@@ -943,99 +669,119 @@ function stepPreparedChunkLineGeometry(
     return null
   }
 
-  function maybeFinishAtSoftHyphen(): number | null {
-    if (pendingBreakKind !== 'soft-hyphen' || pendingBreakSegmentIndex < 0) return null
+  let lineCount = 0
+  let lastLineWidth: number | null = null
+  while (chunkIndex >= 0 && lineCount < lineLimit) {
+    lineStartSegmentIndex = cursor.segmentIndex
+    lineStartGraphemeIndex = cursor.graphemeIndex
+    lineW = 0
+    hasContent = false
+    lineEndSegmentIndex = cursor.segmentIndex
+    lineEndGraphemeIndex = cursor.graphemeIndex
+    pendingBreakSegmentIndex = -1
+    pendingBreakFitWidth = 0
+    pendingBreakPaintWidth = 0
+    pendingBreakKind = null
 
-    if (pendingBreakFitWidth <= fitLimit) {
-      return finishLine(pendingBreakSegmentIndex, 0, pendingBreakPaintWidth)
-    }
+    const chunk = prepared.chunks[chunkIndex]!
+    let lineWidth: number | null = null
+    if (chunk.startSegmentIndex === chunk.endSegmentIndex) {
+      cursor.segmentIndex = chunk.consumedEndSegmentIndex
+      cursor.graphemeIndex = 0
+      lineWidth = 0
+    } else {
+      lineLoop: for (let i = cursor.segmentIndex; i < chunk.endSegmentIndex; i++) {
+        const kind = kinds[i]!
+        const breakAfter = breaksAfter(kind)
+        const startGraphemeIndex = i === cursor.segmentIndex ? cursor.graphemeIndex : 0
+        const leadingSpacing = getLeadingLetterSpacing(prepared, hasContent, i)
+        const w = kind === 'tab'
+          ? getTabAdvance(lineW + leadingSpacing, prepared.tabStopAdvance)
+          : widths[i]!
+        const advance = leadingSpacing + w
+        const fitAdvance = getWholeSegmentFitContribution(prepared, kind, i, leadingSpacing, w)
 
-    return null
-  }
-
-  for (let i = cursor.segmentIndex; i < chunk.endSegmentIndex; i++) {
-    const kind = kinds[i]!
-    const breakAfter = breaksAfter(kind)
-    const startGraphemeIndex = i === cursor.segmentIndex ? cursor.graphemeIndex : 0
-    const leadingSpacing = getLeadingLetterSpacing(prepared, hasContent, i)
-    const w = kind === 'tab'
-      ? getTabAdvance(lineW + leadingSpacing, prepared.tabStopAdvance)
-      : widths[i]!
-    const advance = leadingSpacing + w
-    const fitAdvance = getWholeSegmentFitContribution(prepared, kind, i, leadingSpacing, w)
-
-    if (kind === 'soft-hyphen' && startGraphemeIndex === 0) {
-      if (hasContent) {
-        lineEndSegmentIndex = i + 1
-        lineEndGraphemeIndex = 0
-        if (i + 1 < chunk.endSegmentIndex) {
-          pendingBreakSegmentIndex = i + 1
-          pendingBreakFitWidth = lineW + discretionaryHyphenWidth
-          pendingBreakPaintWidth = lineW + discretionaryHyphenWidth
-          pendingBreakKind = kind
+        if (kind === 'soft-hyphen' && startGraphemeIndex === 0) {
+          if (hasContent) {
+            lineEndSegmentIndex = i + 1
+            lineEndGraphemeIndex = 0
+            if (i + 1 < chunk.endSegmentIndex) {
+              pendingBreakSegmentIndex = i + 1
+              pendingBreakFitWidth = lineW + discretionaryHyphenWidth
+              pendingBreakPaintWidth = lineW + discretionaryHyphenWidth
+              pendingBreakKind = kind
+            }
+          }
+          continue
         }
-      }
-      continue
-    }
 
-    if (!hasContent) {
-      if (startGraphemeIndex > 0) {
-        const line = appendBreakableSegmentFrom(i, startGraphemeIndex)
-        if (line !== null) return line
-      } else if (fitAdvance > fitLimit && breakableFitAdvances[i] !== null) {
-        const line = appendBreakableSegmentFrom(i, 0)
-        if (line !== null) return line
-      } else {
-        startLineAtSegment(i, w)
-      }
-      updatePendingBreakForWholeSegment(kind, breakAfter, i, w, leadingSpacing, advance)
-      continue
-    }
+        if (!hasContent) {
+          if (startGraphemeIndex > 0) {
+            const line = appendBreakableSegmentFrom(i, startGraphemeIndex)
+            if (line !== null) {
+              lineWidth = line
+              break lineLoop
+            }
+          } else if (fitAdvance > fitLimit && breakableFitAdvances[i] !== null) {
+            const line = appendBreakableSegmentFrom(i, 0)
+            if (line !== null) {
+              lineWidth = line
+              break lineLoop
+            }
+          } else {
+            startLineAtSegment(i, w)
+          }
+          updatePendingBreakForWholeSegment(kind, breakAfter, i, w, leadingSpacing, advance)
+          continue
+        }
 
-    const newFitW = lineW + fitAdvance
-    if (newFitW > fitLimit) {
-      const currentBreakFitWidth =
-        lineW + getBreakOpportunityFitContribution(prepared, kind, i, leadingSpacing)
-      const currentBreakPaintWidth =
-        lineW + getLineEndPaintContribution(prepared, kind, i, leadingSpacing, w)
+        const newFitW = lineW + fitAdvance
+        if (newFitW > fitLimit) {
+          const currentBreakFitWidth =
+            lineW + getBreakOpportunityFitContribution(prepared, kind, i, leadingSpacing)
+          const currentBreakPaintWidth =
+            lineW + getLineEndPaintContribution(prepared, kind, i, leadingSpacing, w)
 
-      const softBreakLine = maybeFinishAtSoftHyphen()
-      if (softBreakLine !== null) return softBreakLine
+          if (breakAfter && currentBreakFitWidth <= fitLimit) {
+            appendWholeSegment(i, advance)
+            lineWidth = finishLine(i + 1, 0, currentBreakPaintWidth)
+            break lineLoop
+          }
 
-      if (breakAfter && currentBreakFitWidth <= fitLimit) {
+          if (pendingBreakSegmentIndex >= 0 && pendingBreakFitWidth <= fitLimit) {
+            if (
+              lineEndSegmentIndex > pendingBreakSegmentIndex ||
+              (lineEndSegmentIndex === pendingBreakSegmentIndex && lineEndGraphemeIndex > 0)
+            ) {
+              lineWidth = finishLine()
+              break lineLoop
+            }
+            lineWidth = finishLine(pendingBreakSegmentIndex, 0, pendingBreakPaintWidth)
+            break lineLoop
+          }
+
+          lineWidth = finishLine()
+          break lineLoop
+        }
+
         appendWholeSegment(i, advance)
-        return finishLine(i + 1, 0, currentBreakPaintWidth)
+        updatePendingBreakForWholeSegment(kind, breakAfter, i, w, leadingSpacing, advance)
       }
 
-      if (pendingBreakSegmentIndex >= 0 && pendingBreakFitWidth <= fitLimit) {
-        if (
-          lineEndSegmentIndex > pendingBreakSegmentIndex ||
-          (lineEndSegmentIndex === pendingBreakSegmentIndex && lineEndGraphemeIndex > 0)
-        ) {
-          return finishLine()
-        }
-        return finishLine(pendingBreakSegmentIndex, 0, pendingBreakPaintWidth)
+      if (lineWidth === null) {
+        lineWidth = pendingBreakSegmentIndex === chunk.consumedEndSegmentIndex && lineEndGraphemeIndex === 0
+          ? finishLine(chunk.consumedEndSegmentIndex, 0, pendingBreakPaintWidth)
+          : finishLine(chunk.consumedEndSegmentIndex, 0, lineW)
       }
-
-      if (fitAdvance > fitLimit && breakableFitAdvances[i] !== null) {
-        const currentLine = finishLine()
-        if (currentLine !== null) return currentLine
-        const line = appendBreakableSegmentFrom(i, 0)
-        if (line !== null) return line
-      }
-
-      return finishLine()
     }
-
-    appendWholeSegment(i, advance)
-    updatePendingBreakForWholeSegment(kind, breakAfter, i, w, leadingSpacing, advance)
+    if (lineWidth === null) break
+    lastLineWidth = lineWidth
+    lineCount++
+    onLine?.(lineWidth, lineStartSegmentIndex, lineStartGraphemeIndex, cursor.segmentIndex, cursor.graphemeIndex)
+    // A single-line caller owns normalization of the following line.
+    if (lineCount < lineLimit) chunkIndex = normalizeLineStartChunkIndexFromHint(prepared, chunkIndex, cursor)
   }
-
-  if (pendingBreakSegmentIndex === chunk.consumedEndSegmentIndex && lineEndGraphemeIndex === 0) {
-    return finishLine(chunk.consumedEndSegmentIndex, 0, pendingBreakPaintWidth)
-  }
-
-  return finishLine(chunk.consumedEndSegmentIndex, 0, lineW)
+  return { lineCount, lastLineWidth }
 }
 
 function stepPreparedSimpleLineGeometry(
@@ -1208,23 +954,11 @@ export function measurePreparedLineGeometry(
   let maxLineWidth = 0
 
   if (!prepared.simpleLineWalkFastPath) {
-    let chunkIndex = normalizePreparedLineStart(prepared, cursor)
-    while (chunkIndex >= 0) {
-      const lineWidth = stepPreparedChunkLineGeometry(prepared, cursor, chunkIndex, maxWidth)
-      if (lineWidth === null) {
-        return {
-          lineCount,
-          maxLineWidth,
-        }
-      }
-      lineCount++
-      if (lineWidth > maxLineWidth) maxLineWidth = lineWidth
-      chunkIndex = normalizeLineStartChunkIndexFromHint(prepared, chunkIndex, cursor)
-    }
-    return {
-      lineCount,
-      maxLineWidth,
-    }
+    const chunkIndex = normalizePreparedLineStart(prepared, cursor)
+    lineCount = walkPreparedComplexLines(prepared, cursor, chunkIndex, maxWidth, width => {
+      if (width > maxLineWidth) maxLineWidth = width
+    }).lineCount
+    return { lineCount, maxLineWidth }
   }
 
   while (true) {

--- a/status/dashboard.json
+++ b/status/dashboard.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-09-06T10:02:30.987Z",
+  "generatedAt": "2026-09-06T10:15:09.285Z",
   "sources": {
     "accuracy": {
       "chrome": "accuracy/chrome.json",

--- a/status/dashboard.json
+++ b/status/dashboard.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-09-06T10:15:09.285Z",
+  "generatedAt": "2026-09-06T11:10:40.258Z",
   "sources": {
     "accuracy": {
       "chrome": "accuracy/chrome.json",
@@ -34,7 +34,7 @@
     "total": 28,
     "geometryMatchCount": 28,
     "geometryMismatchCount": 0,
-    "firstBreakMismatchCount": 7
+    "firstBreakMismatchCount": 0
   },
   "benchmarks": {
     "chrome": {

--- a/status/dashboard.json
+++ b/status/dashboard.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-09-05T22:16:07.274Z",
+  "generatedAt": "2026-09-06T10:02:30.987Z",
   "sources": {
     "accuracy": {
       "chrome": "accuracy/chrome.json",
@@ -40,19 +40,19 @@
     "chrome": {
       "topLevel": {
         "Our library: prepare()": {
-          "ms": 8.850000023841858,
+          "ms": 9,
           "desc": "One cold 500-text measurement batch"
         },
         "Our library: layout()": {
-          "ms": 0.0975,
+          "ms": 0.08700000002980232,
           "desc": "Normalized hot-path throughput per 500-text batch"
         },
         "DOM batch": {
-          "ms": 2.400000035762787,
+          "ms": 2.449999988079071,
           "desc": "Single 400→300px batch resize: write all, then read all"
         },
         "DOM interleaved": {
-          "ms": 29.19999998807907,
+          "ms": 29.200000017881393,
           "desc": "Single 400→300px batch resize: write + read per div"
         }
       },
@@ -66,17 +66,17 @@
           "desc": "60-text shared-corpus batch across widths 180/220/260px; materializes text lines"
         },
         "Our library: walkLineRanges()": {
-          "ms": 0.017499999701976778,
+          "ms": 0.013749999552965166,
           "desc": "60-text shared-corpus batch across widths 180/220/260px; line ranges only, no line text strings"
         },
         "Our library: layoutNextLine()": {
-          "ms": 0.025,
+          "ms": 0.027499999850988388,
           "desc": "60-text shared-corpus batch across widths 180/220/260px; streaming line-by-line layout"
         }
       },
       "richInline": {
         "Our library: measureRichInlineStats()": {
-          "ms": 0.007500000298023224,
+          "ms": 0.007499999552965164,
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; stats only"
         },
         "Our library: walkRichInlineLineRanges()": {
@@ -84,47 +84,47 @@
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; per-line ranges with fragment ownership, no text strings"
         },
         "Our library: materializeRichInlineLineRange()": {
-          "ms": 0.026249999552965163,
+          "ms": 0.026250000298023227,
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; range walker plus per-line materialization"
         },
         "Our library: layoutNextRichInlineLineRange() + materializeRichInlineLineRange()": {
-          "ms": 0.02250000089406967,
+          "ms": 0.02250000014901161,
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; streaming range walk plus per-line materialization"
         }
       },
       "richPreWrap": {
         "Our library: measureLineStats()": {
-          "ms": 0.1825000002980232,
+          "ms": 0.13500000089406966,
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only"
         },
         "Our library: layoutWithLines()": {
-          "ms": 0.24249999970197678,
+          "ms": 0.2674999997019768,
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; materializes text lines"
         },
         "Our library: walkLineRanges()": {
-          "ms": 0.125,
+          "ms": 0.14500000029802323,
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; line ranges only, no line text strings"
         },
         "Our library: layoutNextLine()": {
-          "ms": 0.5224999994039536,
+          "ms": 0.5699999988079071,
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; streaming line-by-line layout"
         }
       },
       "richLong": {
         "Our library: measureLineStats()": {
-          "ms": 0.91875,
+          "ms": 0.9012499995529653,
           "desc": "8 Arabic long-form texts across widths 240/300/360px; stats only"
         },
         "Our library: layoutWithLines()": {
-          "ms": 3.4087499998509885,
+          "ms": 3.39375,
           "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines"
         },
         "Our library: walkLineRanges()": {
-          "ms": 1.4025000005960464,
+          "ms": 1.4024999998509884,
           "desc": "8 Arabic long-form texts across widths 240/300/360px; line ranges only, no line text strings"
         },
         "Our library: layoutNextLine()": {
-          "ms": 3.0162499994039536,
+          "ms": 3.012500000745058,
           "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout"
         }
       },
@@ -139,9 +139,9 @@
           "breakableSegments": 0,
           "width": 300,
           "lineCount": 193,
-          "analysisMs": 1.199999988079071,
-          "measureMs": 2.399999976158142,
-          "prepareMs": 3.5,
+          "analysisMs": 1.100000023841858,
+          "measureMs": 2.300000011920929,
+          "prepareMs": 3.400000035762787,
           "layoutMs": 0.014000000059604644
         },
         {
@@ -155,8 +155,8 @@
           "width": 300,
           "lineCount": 380,
           "analysisMs": 2.300000011920929,
-          "measureMs": 4.600000023841858,
-          "prepareMs": 7,
+          "measureMs": 4.5,
+          "prepareMs": 6.900000035762787,
           "layoutMs": 0.02699999988079071
         },
         {
@@ -170,9 +170,9 @@
           "width": 300,
           "lineCount": 428,
           "analysisMs": 1.5,
-          "measureMs": 4.799999952316284,
-          "prepareMs": 6.5,
-          "layoutMs": 0.051500000059604645
+          "measureMs": 4.700000047683716,
+          "prepareMs": 6.300000011920929,
+          "layoutMs": 0.0525
         },
         {
           "id": "ko-sonagi",
@@ -185,9 +185,9 @@
           "width": 300,
           "lineCount": 332,
           "analysisMs": 1.199999988079071,
-          "measureMs": 3.900000035762787,
-          "prepareMs": 5,
-          "layoutMs": 0.03899999976158142
+          "measureMs": 3.5,
+          "prepareMs": 4.699999988079071,
+          "layoutMs": 0.03900000005960465
         },
         {
           "id": "zh-zhufu",
@@ -199,10 +199,10 @@
           "breakableSegments": 2,
           "width": 300,
           "lineCount": 626,
-          "analysisMs": 3.600000023841858,
-          "measureMs": 7.699999988079071,
-          "prepareMs": 11.300000011920929,
-          "layoutMs": 0.04200000017881393
+          "analysisMs": 3.699999988079071,
+          "measureMs": 7.800000011920929,
+          "prepareMs": 11.5,
+          "layoutMs": 0.0425
         },
         {
           "id": "zh-guxiang",
@@ -214,10 +214,10 @@
           "breakableSegments": 14,
           "width": 300,
           "lineCount": 375,
-          "analysisMs": 2.100000023841858,
+          "analysisMs": 2.199999988079071,
           "measureMs": 4.599999964237213,
-          "prepareMs": 6.899999976158142,
-          "layoutMs": 0.025
+          "prepareMs": 6.800000011920929,
+          "layoutMs": 0.025499999821186066
         },
         {
           "id": "th-nithan-vetal-story-1",
@@ -229,10 +229,10 @@
           "breakableSegments": 8087,
           "width": 300,
           "lineCount": 1024,
-          "analysisMs": 6.300000011920929,
-          "measureMs": 4.200000047683716,
-          "prepareMs": 10.700000047683716,
-          "layoutMs": 0.05700000017881393
+          "analysisMs": 6.400000035762787,
+          "measureMs": 4.199999928474426,
+          "prepareMs": 10.600000023841858,
+          "layoutMs": 0.05650000005960464
         },
         {
           "id": "my-cunning-heron-teacher",
@@ -245,8 +245,8 @@
           "width": 300,
           "lineCount": 81,
           "analysisMs": 0.5,
-          "measureMs": 0.40000003576278687,
-          "prepareMs": 0.8999999761581421,
+          "measureMs": 0.5,
+          "prepareMs": 1,
           "layoutMs": 0.004000000059604645
         },
         {
@@ -260,7 +260,7 @@
           "width": 300,
           "lineCount": 54,
           "analysisMs": 0.30000001192092896,
-          "measureMs": 0.3999999761581421,
+          "measureMs": 0.30000007152557373,
           "prepareMs": 0.6000000238418579,
           "layoutMs": 0.0025
         },
@@ -274,9 +274,9 @@
           "breakableSegments": 2917,
           "width": 300,
           "lineCount": 352,
-          "analysisMs": 1.699999988079071,
-          "measureMs": 2.5000000596046448,
-          "prepareMs": 4.199999988079071,
+          "analysisMs": 1.7999999523162842,
+          "measureMs": 2.300000011920929,
+          "prepareMs": 4.100000023841858,
           "layoutMs": 0.025
         },
         {
@@ -289,10 +289,10 @@
           "breakableSegments": 3547,
           "width": 300,
           "lineCount": 591,
-          "analysisMs": 3.600000023841858,
-          "measureMs": 3.099999964237213,
-          "prepareMs": 6.799999952316284,
-          "layoutMs": 0.055499999821186065
+          "analysisMs": 3.5,
+          "measureMs": 3.299999952316284,
+          "prepareMs": 6.699999988079071,
+          "layoutMs": 0.055999999940395354
         },
         {
           "id": "hi-eidgah",
@@ -304,10 +304,10 @@
           "breakableSegments": 4089,
           "width": 300,
           "lineCount": 653,
-          "analysisMs": 2.699999988079071,
-          "measureMs": 4.500000059604645,
-          "prepareMs": 7.100000023841858,
-          "layoutMs": 0.044000000059604645
+          "analysisMs": 2.600000023841858,
+          "measureMs": 4.5,
+          "prepareMs": 7.099999964237213,
+          "layoutMs": 0.04399999976158142
         },
         {
           "id": "synthetic-long-breakable-runs",
@@ -320,9 +320,9 @@
           "width": 300,
           "lineCount": 2860,
           "analysisMs": 3.5,
-          "measureMs": 7.5,
-          "prepareMs": 11,
-          "layoutMs": 0.2675
+          "measureMs": 7.100000083446503,
+          "prepareMs": 10.699999988079071,
+          "layoutMs": 0.2740000000596046
         },
         {
           "id": "ar-risalat-al-ghufran-part-1",
@@ -334,17 +334,17 @@
           "breakableSegments": 18756,
           "width": 300,
           "lineCount": 2643,
-          "analysisMs": 13,
-          "measureMs": 23.100000023841858,
-          "prepareMs": 39.30000001192093,
-          "layoutMs": 0.16950000017881395
+          "analysisMs": 12.400000035762787,
+          "measureMs": 23.799999952316284,
+          "prepareMs": 35.89999997615814,
+          "layoutMs": 0.17099999994039536
         }
       ]
     },
     "safari": {
       "topLevel": {
         "Our library: prepare()": {
-          "ms": 11.500000000000057,
+          "ms": 11.500000000000028,
           "desc": "One cold 500-text measurement batch"
         },
         "Our library: layout()": {
@@ -352,7 +352,7 @@
           "desc": "Normalized hot-path throughput per 500-text batch"
         },
         "DOM batch": {
-          "ms": 52,
+          "ms": 53,
           "desc": "Single 400→300px batch resize: write all, then read all"
         },
         "DOM interleaved": {
@@ -362,11 +362,11 @@
       },
       "richShared": {
         "Our library: measureLineStats()": {
-          "ms": 0.025,
+          "ms": 0.02499999999999432,
           "desc": "60-text shared-corpus batch across widths 180/220/260px; stats only"
         },
         "Our library: layoutWithLines()": {
-          "ms": 0.025,
+          "ms": 0.025000000000005684,
           "desc": "60-text shared-corpus batch across widths 180/220/260px; materializes text lines"
         },
         "Our library: walkLineRanges()": {
@@ -388,7 +388,7 @@
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; per-line ranges with fragment ownership, no text strings"
         },
         "Our library: materializeRichInlineLineRange()": {
-          "ms": 0.025,
+          "ms": 0.037500000000000006,
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; range walker plus per-line materialization"
         },
         "Our library: layoutNextRichInlineLineRange() + materializeRichInlineLineRange()": {
@@ -398,7 +398,7 @@
       },
       "richPreWrap": {
         "Our library: measureLineStats()": {
-          "ms": 0.22499999999998865,
+          "ms": 0.15,
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only"
         },
         "Our library: layoutWithLines()": {
@@ -406,7 +406,7 @@
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; materializes text lines"
         },
         "Our library: walkLineRanges()": {
-          "ms": 0.15,
+          "ms": 0.2,
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; line ranges only, no line text strings"
         },
         "Our library: layoutNextLine()": {
@@ -420,15 +420,15 @@
           "desc": "8 Arabic long-form texts across widths 240/300/360px; stats only"
         },
         "Our library: layoutWithLines()": {
-          "ms": 3.125,
+          "ms": 3.1,
           "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines"
         },
         "Our library: walkLineRanges()": {
-          "ms": 1.75,
+          "ms": 1.7250000000000114,
           "desc": "8 Arabic long-form texts across widths 240/300/360px; line ranges only, no line text strings"
         },
         "Our library: layoutNextLine()": {
-          "ms": 2.3,
+          "ms": 2.275,
           "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout"
         }
       },
@@ -459,8 +459,8 @@
           "width": 300,
           "lineCount": 380,
           "analysisMs": 2,
-          "measureMs": 5,
-          "prepareMs": 7,
+          "measureMs": 4,
+          "prepareMs": 6,
           "layoutMs": 0.03
         },
         {
@@ -475,7 +475,7 @@
           "lineCount": 428,
           "analysisMs": 2,
           "measureMs": 5.0000000000009095,
-          "prepareMs": 7,
+          "prepareMs": 6.9999999999990905,
           "layoutMs": 0.055
         },
         {
@@ -491,7 +491,7 @@
           "analysisMs": 1,
           "measureMs": 4,
           "prepareMs": 5,
-          "layoutMs": 0.04499999999999545
+          "layoutMs": 0.04
         },
         {
           "id": "zh-zhufu",
@@ -504,8 +504,8 @@
           "width": 300,
           "lineCount": 626,
           "analysisMs": 4,
-          "measureMs": 8.00000000000091,
-          "prepareMs": 12,
+          "measureMs": 9.00000000000091,
+          "prepareMs": 13,
           "layoutMs": 0.045
         },
         {
@@ -519,8 +519,8 @@
           "width": 300,
           "lineCount": 375,
           "analysisMs": 2,
-          "measureMs": 5.9999999999990905,
-          "prepareMs": 8,
+          "measureMs": 4.999999999998181,
+          "prepareMs": 7,
           "layoutMs": 0.025000000000004546
         },
         {
@@ -534,7 +534,7 @@
           "width": 300,
           "lineCount": 1024,
           "analysisMs": 6,
-          "measureMs": 15.000000000002728,
+          "measureMs": 15.99999999999909,
           "prepareMs": 22,
           "layoutMs": 0.06
         },
@@ -548,8 +548,8 @@
           "breakableSegments": 424,
           "width": 300,
           "lineCount": 81,
-          "analysisMs": 0.999999999998181,
-          "measureMs": 2.000000000001819,
+          "analysisMs": 0,
+          "measureMs": 3,
           "prepareMs": 3,
           "layoutMs": 0.005
         },
@@ -578,7 +578,7 @@
           "breakableSegments": 2917,
           "width": 300,
           "lineCount": 352,
-          "analysisMs": 2,
+          "analysisMs": 1.999999999998181,
           "measureMs": 30,
           "prepareMs": 32,
           "layoutMs": 0.035
@@ -609,8 +609,8 @@
           "width": 300,
           "lineCount": 653,
           "analysisMs": 3,
-          "measureMs": 19.00000000000182,
-          "prepareMs": 22.00000000000182,
+          "measureMs": 20,
+          "prepareMs": 23,
           "layoutMs": 0.055
         },
         {
@@ -623,10 +623,10 @@
           "breakableSegments": 1540,
           "width": 300,
           "lineCount": 2860,
-          "analysisMs": 5,
-          "measureMs": 68.99999999999636,
-          "prepareMs": 73,
-          "layoutMs": 0.3450000000000091
+          "analysisMs": 4.999999999998181,
+          "measureMs": 67.00000000000364,
+          "prepareMs": 72.00000000000182,
+          "layoutMs": 0.35
         },
         {
           "id": "ar-risalat-al-ghufran-part-1",
@@ -638,10 +638,10 @@
           "breakableSegments": 18756,
           "width": 300,
           "lineCount": 2644,
-          "analysisMs": 10,
-          "measureMs": 114,
-          "prepareMs": 124.00000000000182,
-          "layoutMs": 0.21
+          "analysisMs": 10.000000000001819,
+          "measureMs": 116,
+          "prepareMs": 126,
+          "layoutMs": 0.20999999999999092
         }
       ]
     }

--- a/tests/wrapping/README.md
+++ b/tests/wrapping/README.md
@@ -59,7 +59,37 @@ after preparation, and retains the unverified-profile TAB compatibility checks.
 
 Most native observations use one unmodified text node and scalar `Range`
 rectangles. Compact maintained cases also preserve their selected Range/span
-extractor; span boundaries can change shaping, so those results stay distinct.
+extractor. Observer version 2 retains each extraction's exact normalized source,
+method, own height, resolved line-height, every grapheme/scalar rectangle and
+whole-content rectangles. Extraction count comes from that experiment's height, not the number
+of inferred source groups. Normalizing source or inserting spans can change
+wrapping; neither experiment replaces the original paragraph's observations.
+
+Boundary comparisons use all positive rectangles of a visible source scalar. A
+carried zero rectangle cannot move it to an earlier line, and positive rectangles
+on multiple lines do not establish one source owner. Invisible controls and
+whitespace likewise do not acquire exact consumed endpoints from rectangle
+order or positivity. An internal unknown between established visible endpoints
+cannot change that source envelope. In normal mode, the existing suppressed-boundary
+contract also removes collapsed ASCII SPACE from compared starts and ends without
+assigning it to either line. The selected span protocol can establish a literal
+preserved SPACE or TAB's source placement when its single nonempty element
+fragment agrees with its scalar Range in that same DOM. This does not turn its
+hanging width into a painted endpoint: the existing boundary comparison still
+trims line ends. Multiple, empty or conflicting fragments remain unobserved.
+For pre-wrap LF, a measured extraction count equal to the number of forced
+source lines excludes additional soft wraps and establishes their whitespace
+boundaries, including consecutive empty lines and the absence of an extra line
+after trailing LF. Other uncertain endpoint controls remain unobserved even on
+a control-only hard line. Non-breaking spaces and other leading/trailing
+controls retain their uncertainty. Known visible mismatches
+remain failures; partial endpoint agreement is `unobserved`, not an exact-boundary
+pass. Required metrics remain required even when their evidence is ambiguous.
+
+Version 1 reports retain their recorded assessments and legacy source groups.
+Those groups lack the extraction's own geometry and cannot be converted into
+version 2 observations. Reassessing such a record leaves selected extraction
+count/boundaries unobserved; original paragraph metrics can still be assessed.
 Canonical accuracy and corpus cases retain their height-only scope. Corpus
 native paragraphs use documented whitespace normalization while the candidate
 still receives the original source.

--- a/tests/wrapping/README.md
+++ b/tests/wrapping/README.md
@@ -51,7 +51,9 @@ Height, extracted line count/boundaries, source placement, whitespace, widths,
 selected hyphens, public API contracts and selected native rich-item heights
 remain separate. `unobserved` and
 `not-applicable` are never passes. Interrupted API groups retain their failures
-and discard partial passes. API agreement does not establish native correctness.
+and discard partial passes. API agreement does not establish native correctness. Line comparisons include all
+serialized returned fields, so agreeing text and source positions cannot hide
+lost break metadata. Widths retain their existing numeric tolerance.
 The numeric companion covers nine environment profiles, prohibits Canvas calls
 after preparation, and retains the unverified-profile TAB compatibility checks.
 

--- a/tests/wrapping/VALIDATION.md
+++ b/tests/wrapping/VALIDATION.md
@@ -8,6 +8,57 @@ opposites discovered during review.
 [README.md](README.md) explains the runner; [INVENTORY.md](INVENTORY.md) records
 coverage, provenance and research protocols outside its scope.
 
+## Shared complex line walker
+
+The production foundation starts at published main `cdc34f1`. Complex batch,
+streaming, ranges and statistics now share one decision loop, retaining the
+simple fast path. A later fitting boundary has the same priority over an earlier
+SHY in every API. Line-start normalization also crosses consecutive consumed-only
+chunks without dropping later text or suppressing real empty lines. Preparation,
+measurements, prepared fields and the public API are unchanged.
+
+The full shared inventory comparison covers 656,402 native inputs in Chrome,
+Safari and Firefox, both directions. It removes API disagreement on 19,054 rows
+(6,252 Chrome, 6,214 Safari, 6,588 Firefox), with no lost native accuracy successes
+and identical batch text, widths and cursors. Seven source-conservation diagnostics
+change with corrected streaming; API agreement and exact source partition remain
+separate claims. The normalizer correction preserves every full-run prediction;
+its previously missing counterexample is covered by one small regression test.
+The final cleanup removes only independently proven unreachable code. A further
+4,380 producer-created comparisons preserve batch output and contracts, including
+mutated callbacks, reentrant calls and copied continuations.
+
+All 33,622 ordinary observations pass the final baseline-preservation and maintained
+absolute gates. Nine numeric environment profiles pass too. The final ordinary
+suite hash is `0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f`.
+The exploratory full run uses additional proposed source obligations already
+failed by published main; those failures remain recorded and are not waived or
+promoted as passing. This foundation does not resolve flat #210/#211. The broader
+source-boundary candidates still have main regressions and remain separate.
+
+Unit tests (174 tests, 1,070 assertions), strict checks, the static site build and
+packed JS/TypeScript consumer checks pass. Three focused regressions protect
+complete returned-line metadata, later hanging boundaries after SHY, and progress
+across consecutive consumed-only chunks. Accuracy, spacing, corpus, benchmark
+snapshots and dashboards were refreshed.
+
+Foreground benchmark snapshots use medians of three page runs against a fresh
+published-source reference. Ordinary layout and the long Arabic rich workload
+stay close to baseline. Pre-wrap stats improve from 0.180 to 0.135 ms in Chrome
+and 0.250 to 0.150 ms in Safari; range walking rises from 0.125 to 0.145 ms and
+0.150 to 0.200 ms respectively. Chrome pre-wrap streaming rises from 0.525 to
+0.570 ms, while Safari remains 0.500 ms. These small absolute stress-case costs
+are retained; the refactor is not a universal speedup. Counted work finds no
+quadratic traversal, but complex preferred-cut searches now cost
+O(lines × log(cuts)), as documented in [RESEARCH.md](../../RESEARCH.md).
+
+Artifacts under `/private/tmp/pretext-production-20260905`: full native rows and
+pair audits in `published-shared-walker-v4-full-{chrome,safari,firefox}`, final
+ordinary observations in `production-foundation/.artifacts/wrapping/2026-09-06T09-58-30.242Z-260d6702`,
+producer proof in `review-foundation-v3/semantics-v5.json`, and benchmark comparison
+in `foundation-v5-timing-comparison.json`. Frozen V5 source matches the final
+production runtime; V4 differs only by the reviewed unreachable-code cleanup.
+
 ## Algorithmic-work audit and repairs
 
 The history/current-code audit repaired three inherited repeated scans:

--- a/tests/wrapping/VALIDATION.md
+++ b/tests/wrapping/VALIDATION.md
@@ -30,8 +30,10 @@ mutated callbacks, reentrant calls and copied continuations.
 
 All 33,622 ordinary observations pass the final baseline-preservation and maintained
 absolute gates. Nine numeric environment profiles pass too. The final ordinary
-suite hash is `0fd378ba100c1ddbcbb8f2b33a95273fada13fdff195fa76024ad33b22a7302f`.
-The exploratory full run uses additional proposed source obligations already
+suite hash is `c3f9748217abee9c8b2c72c79c5c8ff7a7bc77c84b6cfae5b7508864b5d346fa`.
+After reviewing the per-case changes, the baseline advances to runtime commit
+`2b73992`, protecting its newly gained API successes. The ordinary snapshots
+were regenerated against that pin; all gates pass again. The exploratory full run uses additional proposed source obligations already
 failed by published main; those failures remain recorded and are not waived or
 promoted as passing. This foundation does not resolve flat #210/#211. The broader
 source-boundary candidates still have main regressions and remain separate.
@@ -54,7 +56,7 @@ O(lines × log(cuts)), as documented in [RESEARCH.md](../../RESEARCH.md).
 
 Artifacts under `/private/tmp/pretext-production-20260905`: full native rows and
 pair audits in `published-shared-walker-v4-full-{chrome,safari,firefox}`, final
-ordinary observations in `production-foundation/.artifacts/wrapping/2026-09-06T09-58-30.242Z-260d6702`,
+ordinary observations in `production-foundation/.artifacts/wrapping/2026-09-06T10-13-29.944Z-9c7aae7d`,
 producer proof in `review-foundation-v3/semantics-v5.json`, and benchmark comparison
 in `foundation-v5-timing-comparison.json`. Frozen V5 source matches the final
 production runtime; V4 differs only by the reviewed unreachable-code cleanup.

--- a/tests/wrapping/VALIDATION.md
+++ b/tests/wrapping/VALIDATION.md
@@ -8,6 +8,57 @@ opposites discovered during review.
 [README.md](README.md) explains the runner; [INVENTORY.md](INVENTORY.md) records
 coverage, provenance and research protocols outside its scope.
 
+## Extraction-stage observation
+
+This follow-up changes test instrumentation only; all library sources are
+identical to the shared-walker foundation. Observer version 2 records the
+selected extraction's exact source and geometry separately from the original
+paragraph. Its measured height establishes line count even when rectangles do
+not establish exact source ownership. Known scalar mismatches remain failures;
+ambiguous boundaries remain unobserved. Preserved LF topology and corroborated
+literal SPACE/TAB span fragments recover established whitespace boundaries.
+No case, required metric, tolerance or baseline revision changes.
+
+The final fresh ordinary run passes the maintained and baseline-preservation
+gates in all three browsers: 33,622 inputs and nine numeric environment profiles.
+Every prediction and original paragraph observation is identical to the final
+foundation run. All previously passing boundary assessments are preserved.
+Five Safari boundary failures were caused by the old extraction and now pass.
+The `trans\u00adatlantic transit` boundary is unobserved in Chrome and Safari:
+its control rectangles do not establish the exact source endpoint. This corrects
+two formerly asserted failures, without changing their other assessments or
+claiming a library fix.
+
+The initial version-2 native full run covers 656,402 inputs and passes the same
+gates. Its core predictions and original native observations match the earlier
+full foundation run throughout. Five inputs per browser carry additional
+provenance and proposed assertions in the experimental reference harness; the
+audit records those metadata differences separately. No physical input differs.
+The final LF/SPAN refinement changes only boundary assessment, so its full-run
+validation reuses the saved native observations; the final ordinary run freshly
+observes all selected extraction cases. All 84 selected full-run inputs and
+extraction records (42 Chrome, 42 Safari) exactly match that fresh ordinary run.
+Reassessment restores 17 previously uncertain boundaries in each browser and
+changes no other metric status or required success. This is not a second fresh
+full sweep.
+
+Unit tests pass (181 tests, 1,119 assertions), as do strict TypeScript/lint/Knip,
+the static site build and diff checks. Independent offline probes check 2,585
+candidate source partitions and seven SPAN corroboration controls, with no false
+passes or failures. Accuracy, spacing and corpus snapshots and both dashboards
+were refreshed from the final ordinary run. Library benchmarks and package
+checks remain those of the unchanged foundation.
+
+The final ordinary suite hash is
+`0f51943935e2ee005c52dfb58236dc42e0ce23b303c631c9cec6535e70a42d51`.
+Artifacts under `/private/tmp/pretext-production-20260905` are
+`observer-v2-final-ordinary`, `observer-v2-full-{chrome,safari,firefox}`,
+`observer-version-final-audit.json`, `observer-version-full-audit.json` and
+`observer-boundary-coverage-audit`. The initial full observer hash is
+`e879a5ac5755832d3f409b17f99138af18f201021f4d3a63b606bfd024b5623f`.
+These are observation corrections; flat #210/#211 and the rejected source-model
+candidates remain separate.
+
 ## Shared complex line walker
 
 The production foundation starts at published main `cdc34f1`. Complex batch,

--- a/tests/wrapping/baseline.json
+++ b/tests/wrapping/baseline.json
@@ -1,4 +1,4 @@
 {
-  "revision": "ac6289f137542ed7d9e46a91089023166d29bd54",
-  "description": "Reviewed wrapping boundary and rich-inline fixes. The runner measures this source and every candidate against the same fresh browser observations; existing mismatches remain observations, never expected answers."
+  "revision": "2b73992faeb92b3247cd390871180b8588fe1a95",
+  "description": "Reviewed boundary, rich-inline and shared complex-walker fixes. The runner measures this source and every candidate against the same fresh browser observations; existing mismatches remain observations, never expected answers."
 }

--- a/tests/wrapping/browser.ts
+++ b/tests/wrapping/browser.ts
@@ -156,7 +156,7 @@ export async function runBrowser(variants: Variant[]): Promise<void> {
       for (const variant of variants) richContracts.push({ name: variant.name, font, letterSpacing, ...variant.checkRichContracts({ font, letterSpacing }, includeStructure) })
     }
     const report: BrowserReport = {
-      status: 'ready', observerVersion: 1, contexts, rowCount: inputs.length, richContracts,
+      status: 'ready', observerVersion: 2, contexts, rowCount: inputs.length, richContracts,
       environment: {
         context: config.context,
         userAgent: navigator.userAgent, dpr: devicePixelRatio,

--- a/tests/wrapping/contracts.ts
+++ b/tests/wrapping/contracts.ts
@@ -61,9 +61,21 @@ function sameWidth(a: number, b: number): boolean {
   return Number.isFinite(a) && Number.isFinite(b) && Math.abs(a - b) < 0.000001
 }
 
+function orderedJSONValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(orderedJSONValue)
+  if (value === null || typeof value !== 'object') return value
+  const record = value as Record<string, unknown>
+  const ordered: Record<string, unknown> = {}
+  for (const key of Object.keys(record).sort()) ordered[key] = orderedJSONValue(record[key])
+  return ordered
+}
+
 function sameLine(a: Line | null, b: Line | null): boolean {
   if (a === null || b === null) return a === b
-  return a.text === b.text && sameWidth(a.width, b.width) && sameCursor(a.start, b.start) && sameCursor(a.end, b.end)
+  if (!sameWidth(a.width, b.width)) return false
+  // Paint metadata can differ even when text and source cursors agree. Compare
+  // every returned field without prescribing an experimental representation.
+  return JSON.stringify(orderedJSONValue({ ...a, width: 0 })) === JSON.stringify(orderedJSONValue({ ...b, width: 0 }))
 }
 
 function sameLines(a: Line[], b: Line[]): boolean {

--- a/tests/wrapping/observe.test.ts
+++ b/tests/wrapping/observe.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'bun:test'
 import type { Prediction } from './contracts.ts'
 import { assess } from './observe.ts'
-import type { NativeObservation, NativePoint, WrappingCase } from './types.ts'
+import type { NativeExtraction, NativeObservation, NativePoint, WrappingCase } from './types.ts'
 
 const base: WrappingCase = {
   id: 'observer', family: 'observer', origins: ['observer-unit-test'], text: '',
@@ -26,6 +26,10 @@ function point(text: string, start: number, line: number): NativePoint {
 
 function native(points: NativePoint[], lineCount: number): NativeObservation {
   return { points, lineCount, height: lineCount * 48, lineRects: [] }
+}
+
+function extraction(source: string, units: NativePoint[], count: number, method: 'range' | 'span' = 'range'): NativeExtraction {
+  return { method, source, units, points: units, height: count * 48, usedLineHeight: 48, lineRects: [] }
 }
 
 test('rich inline height is independently observed and cannot inherit a flat or API pass', () => {
@@ -139,24 +143,186 @@ test('maintained height criteria keep their original exact and rounding semantic
   expect(assess({ ...input, heightMode: 'accuracy' }, { ...oracle, height: predicted.height - 1 }, predicted, 'chrome').height.status).toBe('fail')
 })
 
-test('selected line extraction independently checks count and normalized source breaks', () => {
-  const input: WrappingCase = { ...base, text: 'ab cd', lineMethod: 'span' }
-  const oracle = { ...native([point('a', 0, 0), point('b', 1, 0), point('c', 3, 1), point('d', 4, 1)], 2), extractedLines: [{ start: 0, end: 2 }, { start: 3, end: 5 }] }
-  const correct = prediction(input.text, [['ab', 0, 3], ['cd', 3, 5]])
+test('selected extraction keeps its own height and proves unambiguous visible boundaries', () => {
+  const input: WrappingCase = { ...base, text: 'abcd', lineMethod: 'span' }
+  const units = [point('a', 0, 0), point('b', 1, 0), point('c', 2, 1), point('d', 3, 1)]
+  const oracle = { ...native(units, 2), extraction: extraction(input.text, units, 2, 'span') }
+  const correct = prediction(input.text, [['ab', 0, 2], ['cd', 2, 4]])
   expect(assess(input, oracle, correct, 'chrome').lineCount.status).toBe('pass')
   expect(assess(input, oracle, correct, 'chrome').breaks.status).toBe('pass')
-  const wrong = prediction(input.text, [['a', 0, 1], ['b cd', 1, 5]])
+  const wrong = prediction(input.text, [['a', 0, 1], ['bcd', 1, 4]])
   expect(assess(input, oracle, wrong, 'chrome').lineCount.status).toBe('pass')
   expect(assess(input, oracle, wrong, 'chrome').breaks.status).toBe('fail')
-  const countMismatch = { ...oracle, extractedLines: [{ start: 0, end: 5 }] }
+  // A span intervention can change wrapping while the original text node does not.
+  const countMismatch = { ...oracle, extraction: { ...oracle.extraction, height: 3 * 48 } }
   expect(assess(input, countMismatch, correct, 'chrome').height.status).toBe('pass')
+  expect(assess(input, countMismatch, correct, 'chrome').source.status).toBe('pass')
   expect(assess(input, countMismatch, correct, 'chrome').lineCount.status).toBe('fail')
-  expect(assess(input, native(oracle.points, 2), correct, 'chrome').lineCount.status).toBe('unobserved')
+  const differentSource = { ...oracle, extraction: { ...oracle.extraction, source: 'other source' } }
+  expect(assess(input, differentSource, correct, 'chrome').lineCount.status).toBe('unobserved')
+  const differentMethod = { ...oracle, extraction: { ...oracle.extraction, method: 'range' as const } }
+  expect(assess(input, differentMethod, correct, 'chrome').breaks.status).toBe('unobserved')
+})
+
+test('legacy source groups cannot supply missing extraction-stage geometry', () => {
+  const input: WrappingCase = { ...base, text: 'ab', lineMethod: 'range' }
+  const legacy = { ...native([point('a', 0, 0), point('b', 1, 1)], 2), extractedLines: [{ start: 0, end: 2 }] }
+  const correct = prediction(input.text, [['a', 0, 1], ['b', 1, 2]])
+  const result = assess(input, legacy, correct, 'safari')
+  expect(result.height.status).toBe('pass')
+  expect(result.source.status).toBe('pass')
+  expect(result.lineCount.status).toBe('unobserved')
+  expect(result.breaks.status).toBe('unobserved')
+})
+
+test('collapsed normal-mode SPACE ownership cannot change the visible boundary envelope', () => {
+  const input: WrappingCase = { ...base, text: 'ab cd', lineMethod: 'span' }
+  const space: NativePoint = { text: ' ', start: 2, end: 3, rects: [] }
+  const units = [point('a', 0, 0), point('b', 1, 0), space, point('c', 3, 1), point('d', 4, 1)]
+  const oracle = { ...native(units, 2), extraction: extraction(input.text, units, 2, 'span') }
+  const trailingSpace = prediction(input.text, [['ab', 0, 3], ['cd', 3, 5]])
+  const leadingSpace = prediction(input.text, [['ab', 0, 2], ['cd', 2, 5]])
+  expect(assess(input, oracle, trailingSpace, 'safari').breaks.status).toBe('pass')
+  expect(assess(input, oracle, leadingSpace, 'safari').breaks.status).toBe('pass')
+  expect(assess({ ...input, whiteSpace: 'pre-wrap' }, oracle, trailingSpace, 'safari').breaks.status).toBe('unobserved')
+  const extraLine = prediction(input.text, [['ab', 0, 2], ['', 2, 3], ['cd', 3, 5]])
+  expect(assess(input, oracle, extraLine, 'safari').breaks.status).toBe('fail')
+  const nbsp = { ...input, text: 'ab\u00a0cd' }
+  const nbspUnits = units.map(unit => unit === space ? { ...unit, text: '\u00a0' } : unit)
+  const nbspOracle = { ...native(nbspUnits, 2), extraction: extraction(nbsp.text, nbspUnits, 2, 'span') }
+  expect(assess(nbsp, nbspOracle, prediction(nbsp.text, [['ab', 0, 3], ['cd', 3, 5]]), 'safari').breaks.status).toBe('unobserved')
+})
+
+test('preserved LF topology establishes hard-line endpoints only when its measured count excludes soft wraps', () => {
+  const input: WrappingCase = { ...base, lineMethod: 'range', whiteSpace: 'pre-wrap' }
+  function check(text: string, spans: Array<[string, number, number]>) {
+    const predicted = prediction(text, spans)
+    const points = spans.flatMap(([, start, end], line) => Array.from(text.slice(start, end), (scalar, offset) =>
+      /[ \t\n\u00ad\u200b\u2060]/u.test(scalar)
+        ? { text: scalar, start: start + offset, end: start + offset + 1, rects: [] }
+        : point(scalar, start + offset, line)))
+    const oracle = { ...native(points, spans.length), extraction: extraction(text, points, spans.length) }
+    return { result: assess({ ...input, text }, oracle, predicted, 'safari'), oracle, predicted }
+  }
+  for (const [text, spans] of [
+    ['', []],
+    ['\n', [['', 0, 1]]],
+    ['\n\n', [['', 0, 1], ['', 1, 2]]],
+    ['a\n', [['a', 0, 2]]],
+    [' \n\t\nb', [[' ', 0, 2], ['\t', 2, 4], ['b', 4, 5]]],
+    ['a\n  b', [['a', 0, 2], ['  b', 2, 5]]],
+    ['a\u2060b\n', [['ab', 0, 4]]],
+  ] as Array<[string, Array<[string, number, number]>]>) expect(check(text, spans).result.breaks.status).toBe('pass')
+  for (const [text, spans] of [
+    ['\u2060\n', [['\u2060', 0, 2]]],
+    ['\n\u200b\n', [['', 0, 1], ['\u200b', 1, 3]]],
+    ['a\n\u00ad', [['a', 0, 2], ['\u00ad', 2, 3]]],
+    ['ab\nc', [['a', 0, 1], ['b', 1, 3], ['c', 3, 4]]],
+  ] as Array<[string, Array<[string, number, number]>]>) expect(check(text, spans).result.breaks.status).toBe('unobserved')
+  const { oracle, predicted } = check('a\nb', [['a', 0, 2], ['b', 2, 3]])
+  oracle.extraction.points[2] = point('b', 2, 0)
+  expect(assess({ ...input, text: 'a\nb' }, oracle, predicted, 'safari').breaks.status).toBe('fail')
+  const indent = check(' a\n', [[' a', 0, 3]])
+  expect(assess({ ...input, text: ' a\n' }, indent.oracle, prediction(' a\n', [['a', 1, 3]]), 'safari').breaks.status).toBe('fail')
+})
+
+test('literal preserved span boxes can establish whitespace ownership without interpreting arbitrary Range rectangles', () => {
+  const input: WrappingCase = { ...base, text: 'a b', lineMethod: 'span', whiteSpace: 'pre-wrap' }
+  const units = [point('a', 0, 0), point(' ', 1, 0), point('b', 2, 1)]
+  const stage = extraction(input.text, units, 2, 'span')
+  const oracle = { ...native(units, 2), extraction: stage }
+  const correct = prediction(input.text, [['a ', 0, 2], ['b', 2, 3]])
+  expect(assess(input, oracle, correct, 'safari').breaks.status).toBe('pass')
+  expect(assess(input, oracle, prediction(input.text, [['a', 0, 1], [' b', 1, 3]]), 'safari').breaks.status).toBe('fail')
+  const unknownSpace = { ...units[1]!, rects: [] }
+  const zeroSpace = { ...units[1]!, rects: units[1]!.rects.map(rect => ({ ...rect, width: 0 })) }
+  for (const [box, scalar] of [
+    [unknownSpace, units[1]!],
+    [zeroSpace, zeroSpace],
+    [{ ...units[1]!, rects: [...units[1]!.rects, ...zeroSpace.rects] }, units[1]!],
+    [units[1]!, point(' ', 1, 1)],
+    [{ ...units[1]!, text: ' \u0301', end: 3 }, units[1]!],
+  ]) {
+    const ambiguous = { ...stage, units: [units[0]!, box!, units[2]!], points: [units[0]!, scalar!, units[2]!] }
+    expect(assess(input, { ...oracle, extraction: ambiguous }, correct, 'safari').breaks.status).toBe('unobserved')
+  }
+  expect(assess({ ...input, lineMethod: 'range' }, { ...oracle, extraction: { ...stage, method: 'range' } }, correct, 'safari').breaks.status).toBe('unobserved')
+  for (const scalar of ['\t', '\u00a0', '\u2060']) {
+    const text = `a${scalar}b`
+    const points = units.map(unit => unit.start === 1 ? { ...unit, text: scalar } : unit)
+    const result = assess({ ...input, text }, { ...oracle, extraction: extraction(text, points, 2, 'span') }, prediction(text, [[text.slice(0, 2), 0, 2], ['b', 2, 3]]), 'safari')
+    expect(result.breaks.status).toBe(scalar === '\t' ? 'pass' : 'unobserved')
+  }
+})
+
+test('mixed graphemes retain visible scalar evidence and internal controls do not obscure fixed endpoints', () => {
+  const input: WrappingCase = { ...base, text: 'a\u200db', lineMethod: 'range' }
+  const a = point('a', 0, 0), b = point('b', 2, 0)
+  const control: NativePoint = { text: '\u200d', start: 1, end: 2, rects: [] }
+  const mixed: NativePoint = { text: 'a\u200d', start: 0, end: 2, rects: [] }
+  const stage = { ...extraction(input.text, [mixed, b], 1), points: [a, control, b] }
+  const oracle = { ...native(stage.points, 1), extraction: stage }
+  const correct = prediction(input.text, [['ab', 0, 3]])
+  expect(assess(input, oracle, correct, 'safari').breaks.status).toBe('pass')
+  const wrong = prediction(input.text, [['', 0, 0], ['ab', 0, 3]])
+  expect(assess(input, oracle, wrong, 'safari').breaks.status).toBe('fail')
+  for (const text of ['\u200dab', 'ab\u200d']) {
+    const points = Array.from(text, (scalar, index) => scalar === '\u200d'
+      ? { text: scalar, start: index, end: index + 1, rects: [] }
+      : point(scalar, index, 0))
+    const edgeOracle = { ...native(points, 1), extraction: extraction(text, points, 1) }
+    expect(assess({ ...input, text }, edgeOracle, prediction(text, [['ab', 0, 3]]), 'safari').breaks.status).toBe('unobserved')
+  }
+})
+
+test('carried zero rectangles do not erase a line or assign invisible source ownership', () => {
+  // Captured Safari Arial16, pre-wrap, width0: a / WJ / acute / b / ZWSP / i.
+  // WJ has two zero rectangles; even ZWSP has a positive rectangle.
+  const input: WrappingCase = { ...base, text: 'a\u2060\u0301b\u200Bi', lineMethod: 'range', whiteSpace: 'pre-wrap', width: 0, lineHeight: 24 }
+  const rect = (y: number, width: number) => ({ x: 0, y, width, height: 17 })
+  const units: NativePoint[] = [
+    { text: 'a', start: 0, end: 1, rects: [rect(3, 8.8984375)] },
+    { text: '\u2060', start: 1, end: 2, rects: [rect(3, 0), rect(27, 0)] },
+    { text: '\u0301', start: 2, end: 3, rects: [rect(27, 0), rect(51, 2.96875)] },
+    { text: 'b', start: 3, end: 4, rects: [rect(51, 0), rect(75, 8.8984375)] },
+    { text: '\u200B', start: 4, end: 5, rects: [rect(75, 0), rect(99, 2.96875)] },
+    { text: 'i', start: 5, end: 6, rects: [rect(99, 0), rect(123, 3.5546875)] },
+  ]
+  const stage: NativeExtraction = { method: 'range', source: input.text, height: 144, usedLineHeight: 24, units, points: units, lineRects: [rect(3, 8.8984375), rect(27, 0), rect(51, 2.96875), rect(75, 8.8984375), rect(99, 2.96875), rect(123, 3.5546875)] }
+  const oracle: NativeObservation = { height: 144, lineCount: 6, points: units, lineRects: stage.lineRects, extraction: stage }
+  const six = prediction(input.text, units.map(unit => [unit.text, unit.start, unit.end]))
+  six.height = six.countedHeight = 144
+  expect(assess(input, oracle, six, 'safari').height.status).toBe('pass')
+  expect(assess(input, oracle, six, 'safari').lineCount.status).toBe('pass')
+  expect(assess(input, oracle, six, 'safari').breaks.status).toBe('unobserved')
+  const five = prediction(input.text, [['a\u2060', 0, 2], ['\u0301', 2, 3], ['b', 3, 4], ['\u200B', 4, 5], ['i', 5, 6]])
+  five.height = five.countedHeight = 120
+  expect(assess(input, oracle, five, 'safari').lineCount.status).toBe('fail')
+  expect(assess(input, oracle, five, 'safari').breaks.status).toBe('fail')
+  const wrong = prediction(input.text, [['a', 0, 1], ['\u2060', 1, 2], ['', 2, 2], ['\u0301b', 2, 4], ['\u200B', 4, 5], ['i', 5, 6]])
+  wrong.height = wrong.countedHeight = 144
+  expect(assess(input, oracle, wrong, 'safari').lineCount.status).toBe('pass')
+  expect(assess(input, oracle, wrong, 'safari').breaks.status).toBe('fail')
+})
+
+test('multiple positive rectangles cannot choose the following letter source line', () => {
+  // Chrome's b after a selected SHY carries the preceding hyphen rectangle.
+  const input: WrappingCase = { ...base, text: 'a\u00adb', lineMethod: 'range' }
+  const b = point('b', 2, 1)
+  b.rects.push(...point('b', 2, 2).rects)
+  const units = [point('a', 0, 0), point('\u00ad', 1, 1), b]
+  const oracle = { ...native(units, 3), extraction: extraction(input.text, units, 3) }
+  const correctCount = prediction(input.text, [['a', 0, 1], ['-', 1, 2], ['b', 2, 3]])
+  expect(assess(input, oracle, correctCount, 'chrome').lineCount.status).toBe('pass')
+  expect(assess(input, oracle, correctCount, 'chrome').breaks.status).toBe('unobserved')
+  b.rects.reverse()
+  expect(assess(input, oracle, correctCount, 'chrome').breaks.status).toBe('unobserved')
 })
 
 test('legacy geometry uses its actual layout height and materialized line count', () => {
   const input: WrappingCase = { ...base, text: 'a', heightMode: 'exact', heightSource: 'layout', lineMethod: 'span' }
-  const oracle = { ...native([point('a', 0, 0)], 1), extractedLines: [{ start: 0, end: 1 }] }
+  const units = [point('a', 0, 0)]
+  const oracle = { ...native(units, 1), extraction: extraction(input.text, units, 1, 'span') }
   const result = { ...prediction('a', [['a', 0, 1]]), height: 96, lineCount: 2 }
   expect(assess(input, oracle, result, 'chrome').height.status).toBe('pass')
   expect(assess(input, oracle, result, 'chrome').lineCount.status).toBe('pass')

--- a/tests/wrapping/observe.ts
+++ b/tests/wrapping/observe.ts
@@ -1,6 +1,6 @@
 import { normalizeSource, type Prediction, type PredictionLine } from './contracts.ts'
 import type {
-  Assessment, BrowserKind, MetricResult, NativeObservation, NativePoint, NativeRect, WrappingCase,
+  Assessment, BrowserKind, MetricResult, NativeExtraction, NativeObservation, NativePoint, NativeRect, WrappingCase,
 } from './types.ts'
 
 const RECT_EPSILON = 0.00001
@@ -15,58 +15,60 @@ const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme
 // boundaries are an intervention, so keep this observation separate from the
 // unmodified paragraph's height and scalar rectangles. Units come from source
 // graphemes, never a candidate's private prepared representation.
-function extractNativeLines(element: HTMLElement, input: WrappingCase): NonNullable<NativeObservation['extractedLines']> {
+function observeLineExtraction(element: HTMLElement, input: WrappingCase): Omit<NativeExtraction, 'usedLineHeight'> {
   const text = normalizeSource(input.text, input.whiteSpace)
-  const units = Array.from(graphemeSegmenter.segment(text))
-  const lines: NonNullable<NativeObservation['extractedLines']> = []
+  const sourceUnits = Array.from(graphemeSegmenter.segment(text))
   element.textContent = text
-  const tops: Array<number | null> = []
-  switch (input.lineMethod) {
-    case 'span': {
-      const spans = units.map(unit => {
-        const span = document.createElement('span')
-        span.textContent = unit.segment
-        return span
-      })
-      element.replaceChildren(...spans)
-      for (const span of spans) {
-        const rect = span.getBoundingClientRect()
-        tops.push(rect.width > 0 || rect.height > 0 ? rect.top : null)
-      }
-      break
-    }
-    case 'range': {
-      const node = element.firstChild
-      if (node === null) return lines
-      const range = document.createRange()
-      for (const unit of units) {
+  const method = input.lineMethod
+  if (method === undefined) throw new Error('A line extraction method is required.')
+  const spans = method === 'span' ? sourceUnits.map(unit => {
+    const span = document.createElement('span')
+    span.textContent = unit.segment
+    return span
+  }) : []
+  if (method === 'span') element.replaceChildren(...spans)
+  const origin = element.getBoundingClientRect()
+  const relative = (rect: DOMRect): NativeRect => ({
+    x: rect.x - origin.x, y: rect.y - origin.y, width: rect.width, height: rect.height,
+  })
+  const range = document.createRange()
+  const units: NativePoint[] = []
+  const points: NativePoint[] = []
+  for (let index = 0; index < sourceUnits.length; index++) {
+    const unit = sourceUnits[index]!
+    let rects: NativeRect[]
+    switch (method) {
+      case 'range': {
+        const node = element.firstChild!
         range.setStart(node, unit.index)
         range.setEnd(node, unit.index + unit.segment.length)
-        const rects = range.getClientRects()
-        tops.push(rects.length === 0 ? null : rects[0]!.top)
+        rects = Array.from(range.getClientRects(), relative)
+        break
       }
-      break
+      case 'span': rects = Array.from(spans[index]!.getClientRects(), relative); break
     }
-    case undefined: throw new Error('A line extraction method is required.')
-  }
-  let start = 0
-  let end = 0
-  let lastTop: number | null = null
-  const push = (): void => {
-    if (end > start) lines.push({ start, end: start + text.slice(start, end).trimEnd().length })
-  }
-  for (let index = 0; index < units.length; index++) {
-    const unit = units[index]!
-    const top: number | null = tops[index] ?? lastTop
-    if (top !== null && lastTop !== null && top > lastTop + 0.5) {
-      push()
-      start = unit.index
+    const observedUnit = { start: unit.index, end: unit.index + unit.segment.length, text: unit.segment, rects }
+    units.push(observedUnit)
+    if (method === 'range' && unit.segment.length === (unit.segment.codePointAt(0)! > 0xffff ? 2 : 1)) {
+      points.push(observedUnit)
+    } else {
+      const node = method === 'span' ? spans[index]!.firstChild! : element.firstChild!
+      let start = 0
+      for (const scalar of unit.segment) {
+        const end = start + scalar.length
+        const offset = method === 'span' ? 0 : unit.index
+        range.setStart(node, offset + start)
+        range.setEnd(node, offset + end)
+        points.push({ start: unit.index + start, end: unit.index + end, text: scalar, rects: Array.from(range.getClientRects(), relative) })
+        start = end
+      }
     }
-    end = unit.index + unit.segment.length
-    if (top !== null) lastTop = top
   }
-  push()
-  return lines
+  range.selectNodeContents(element)
+  return {
+    method, source: text, height: origin.height, units, points,
+    lineRects: Array.from(range.getClientRects(), relative),
+  }
 }
 
 // One unmodified text node is the oracle. Wrapping every letter in a span
@@ -118,7 +120,7 @@ export function observeNative(input: WrappingCase): NativeObservation {
       }))
       richHeight = element.getBoundingClientRect().height
     }
-    const extractedLines = input.lineMethod === undefined ? undefined : extractNativeLines(element, input)
+    const extraction = input.lineMethod === undefined ? undefined : observeLineExtraction(element, input)
     let usedLineHeight = input.lineHeight
     if (!Number.isInteger(input.lineHeight)) {
       // Safari can use integral line boxes despite retaining a fractional
@@ -132,7 +134,7 @@ export function observeNative(input: WrappingCase): NativeObservation {
     return {
       height: origin.height, lineCount: Math.abs(count - Math.round(count)) < 0.000001 ? Math.round(count) : count, points, lineRects,
       ...(usedLineHeight === input.lineHeight ? {} : { usedLineHeight }),
-      ...(extractedLines === undefined ? {} : { extractedLines }),
+      ...(extraction === undefined ? {} : { extraction: { ...extraction, usedLineHeight } }),
       ...(richHeight === undefined ? {} : { richHeight }),
     }
   } finally {
@@ -166,20 +168,135 @@ function sourceSpans(input: WrappingCase): SourceSpan[] {
   return spans
 }
 
-function rectLine(rect: NativeRect, input: WrappingCase, native: NativeObservation): number | null {
-  const line = Math.floor((rect.y + rect.height / 2) / (native.usedLineHeight ?? input.lineHeight))
-  return line >= 0 && line < Math.round(native.lineCount) ? line : null
+function lineOnGrid(rect: NativeRect, lineHeight: number, lineCount: number): number | null {
+  const line = Math.floor((rect.y + rect.height / 2) / lineHeight)
+  return line >= 0 && line < lineCount ? line : null
 }
 
-function pointLine(point: NativePoint, input: WrappingCase, native: NativeObservation): number | null {
+function rectLine(rect: NativeRect, input: WrappingCase, native: NativeObservation): number | null {
+  return lineOnGrid(rect, native.usedLineHeight ?? input.lineHeight, Math.round(native.lineCount))
+}
+
+function pointLine(point: NativePoint, lineHeight: number, lineCount: number): number | null {
   let line: number | null = null
   for (const rect of point.rects) {
     if (rect.width <= RECT_EPSILON || rect.height <= RECT_EPSILON) continue
-    const next = rectLine(rect, input, native)
+    const next = lineOnGrid(rect, lineHeight, lineCount)
     if (next === null || (line !== null && line !== next)) return null
     line = next
   }
   return line
+}
+
+function extractionLineCount(extraction: NativeExtraction): number | null {
+  const { height, usedLineHeight } = extraction
+  if (!Number.isFinite(height) || height < 0 || !Number.isFinite(usedLineHeight) || usedLineHeight <= 0) return null
+  const count = height / usedLineHeight
+  return Math.abs(count - Math.round(count)) < 0.000001 ? Math.round(count) : null
+}
+
+function forcedLineBounds(source: string, count: number): Array<{ start: number; end: number }> | null {
+  if (!source.includes('\n')) return null
+  const bounds: Array<{ start: number; end: number }> = []
+  let start = 0
+  for (let end = 0; end < source.length; end++) {
+    if (source[end] !== '\n') continue
+    bounds.push({ start, end })
+    start = end + 1
+  }
+  if (start < source.length) bounds.push({ start, end: source.length })
+  // Preserved LF forces one line per interval, including empty intervals. A
+  // trailing LF does not create another final line. Equality with independently
+  // measured height proves there are no additional soft-wrapped lines.
+  return bounds.length === count ? bounds : null
+}
+
+function preservedSpanLine(unit: NativePoint | undefined, point: NativePoint, extraction: NativeExtraction, count: number): number | null {
+  // This selected protocol observes the literal whitespace element's own box,
+  // not a text Range that might carry a neighbouring glyph or zero rectangle.
+  // Require its sole fragment to agree with the scalar Range in the SAME DOM.
+  if (unit === undefined || unit.start !== point.start || unit.end !== point.end || unit.text !== point.text
+    || unit.rects.length !== 1 || point.rects.length !== 1) return null
+  const box = unit.rects[0]!, scalar = point.rects[0]!
+  if (box.width <= RECT_EPSILON || box.height <= RECT_EPSILON
+    || ![box.x, box.y, box.width, box.height, scalar.x, scalar.y, scalar.width, scalar.height].every(Number.isFinite)
+    || Math.abs(box.x - scalar.x) > RECT_EPSILON || Math.abs(box.y - scalar.y) > RECT_EPSILON
+    || Math.abs(box.width - scalar.width) > RECT_EPSILON || Math.abs(box.height - scalar.height) > RECT_EPSILON) return null
+  return lineOnGrid(box, extraction.usedLineHeight, count)
+}
+
+function compareExtractedBreaks(extraction: NativeExtraction, count: number, whiteSpace: WrappingCase['whiteSpace'], prediction: Extract<Prediction, { detail: 'full' }>): MetricResult {
+  if (prediction.normalized !== extraction.source) {
+    return { status: 'fail', detail: 'Predicted normalized source differs from the selected extraction source.' }
+  }
+  const lines = prediction.lines
+  const bounds = Array.from({ length: count }, () => ({ start: -1, end: -1 }))
+  const uncertain: NativePoint[] = []
+  let lineIndex = 0
+  let unitIndex = 0
+  let observed = 0
+  for (const point of extraction.points) {
+    // The existing boundary contract allows collapsed ASCII whitespace gaps.
+    // Its ownership cannot affect trimmed ends or suppressed normal-mode starts.
+    if (whiteSpace === 'normal' && ASCII_SPACE.test(point.text)) continue
+    // A positive rectangle can include an adjacent glyph, and an invisible
+    // control's box does not establish which consumed source range owns it.
+    // In particular, Chrome b after SHY can have positive rectangles on BOTH
+    // the hyphen's line and b's line. Never choose the first or last rectangle.
+    let expected: number | null
+    if (whiteSpace === 'pre-wrap' && extraction.method === 'span' && (point.text === ' ' || point.text === '\t')) {
+      for (; unitIndex < extraction.units.length && extraction.units[unitIndex]!.end <= point.start; unitIndex++) { /* matching source element */ }
+      expected = preservedSpanLine(extraction.units[unitIndex], point, extraction, count)
+    } else {
+      expected = INVISIBLE.test(point.text) ? null : pointLine(point, extraction.usedLineHeight, count)
+    }
+    if (expected === null) { uncertain.push(point); continue }
+    for (; lineIndex < lines.length && lines[lineIndex]!.sourceEnd <= point.start; lineIndex++) { /* monotone source view */ }
+    const actual = lines[lineIndex]
+    if (actual === undefined || lineIndex !== expected || actual.sourceStart > point.start || actual.sourceEnd < point.end) {
+      return { status: 'fail', detail: `Extraction source [${point.start}, ${point.end}) ${JSON.stringify(point.text)} belongs to line ${expected}; prediction does not place it there.` }
+    }
+    const bound = bounds[expected]!
+    if (bound.start === -1) bound.start = point.start
+    bound.end = point.end
+    observed++
+  }
+  if (lines.length !== count) {
+    return { status: 'fail', detail: `Predicted ${lines.length} source ranges; the ${extraction.method} extraction has ${count} measured line boxes.` }
+  }
+  let hardBounds = whiteSpace === 'pre-wrap' ? forcedLineBounds(extraction.source, count) : null
+  if (hardBounds !== null && bounds.some((bound, index) => bound.start !== -1
+    && (bound.start < hardBounds![index]!.start || bound.end > hardBounds![index]!.end))) hardBounds = null
+  let boundIndex = 0
+  let ambiguous = 0
+  for (const point of uncertain) {
+    // LF topology fixes these preserved source intervals without interpreting
+    // a whitespace rectangle. Other controls or unobserved visible scalars at
+    // their endpoints remain ambiguous, even on a control-only hard line.
+    if (hardBounds !== null && (point.text === '\n' || point.text === ' ' || point.text === '\t')) continue
+    for (; boundIndex < bounds.length && bounds[boundIndex]!.end <= point.start; boundIndex++) { /* monotone visible envelope */ }
+    const bound = bounds[boundIndex]
+    // This does not assign an internal control to a painted line. Source
+    // strictly between fixed visible endpoints cannot change those endpoints.
+    if (bound === undefined || bound.start > point.start || bound.end < point.end) ambiguous++
+  }
+  if (ambiguous > 0 || (hardBounds === null && bounds.some(bound => bound.start === -1))) {
+    return { status: 'unobserved', reason: `${observed} extraction scalars agree; ${ambiguous} boundary scalars have unestablished source ownership. Exact endpoints are not determined by rectangle order or positivity.` }
+  }
+  for (let index = 0; index < bounds.length; index++) {
+    const expected = (hardBounds ?? bounds)[index]!
+    const actual = lines[index]!
+    let start = actual.sourceStart
+    if (whiteSpace === 'normal') {
+      for (; start < actual.sourceEnd && prediction.normalized[start] === ' '; start++) { /* suppressed line-start space */ }
+    }
+    const end = actual.sourceStart + prediction.normalized.slice(actual.sourceStart, actual.sourceEnd).trimEnd().length
+    const expectedEnd = expected.start + extraction.source.slice(expected.start, expected.end).trimEnd().length
+    if (start !== expected.start || end !== expectedEnd) {
+      return { status: 'fail', detail: `Line ${index}: predicted source envelope [${start}, ${end}), observed ${extraction.method} [${expected.start}, ${expectedEnd}).` }
+    }
+  }
+  return { status: 'pass' }
 }
 
 function compareSource(
@@ -195,7 +312,7 @@ function compareSource(
     // breaks also do not paint a width-bearing source rectangle.
     if (whitespace && (input.whiteSpace === 'normal' && ASCII_SPACE.test(point.text) || /[\r\n\f]/.test(point.text))) continue
     applicable++
-    const expected = pointLine(point, input, native)
+    const expected = pointLine(point, native.usedLineHeight ?? input.lineHeight, Math.round(native.lineCount))
     if (expected === null) { ambiguous++; continue }
     for (; spanIndex < spans.length && spans[spanIndex]!.rawEnd <= point.start; spanIndex++) { /* monotonic source view */ }
     const start = spans[spanIndex]
@@ -268,8 +385,8 @@ function compareHyphens(input: WrappingCase, native: NativeObservation, lines: P
   const a = native.points.find(point => point.text === 'a')!
   const b = native.points.find(point => point.text === 'b')!
   const shy = native.points.find(point => point.text === '\u00ad')!
-  const aLine = pointLine(a, input, native)
-  const bLine = pointLine(b, input, native)
+  const aLine = pointLine(a, native.usedLineHeight ?? input.lineHeight, Math.round(native.lineCount))
+  const bLine = pointLine(b, native.usedLineHeight ?? input.lineHeight, Math.round(native.lineCount))
   if (aLine === null || bLine === null) return { status: 'unobserved', reason: 'The SHY control letters have ambiguous native rectangles.' }
   const nativeLines: number[] = []
   if (aLine !== bLine) {
@@ -340,13 +457,28 @@ export function assess(
   const height: MetricResult = heightMatches
     ? { status: 'pass' }
     : { status: 'fail', detail: `Predicted height ${predictedHeight}; native ${native.height}.${usedLineHeight === input.lineHeight ? '' : ` Native line boxes use ${usedLineHeight}px; equivalent predicted height ${nativeScaleHeight}.`}` }
-  const expectedLineCount = native.extractedLines?.length ?? native.lineCount
-  const lineCount: MetricResult = input.lineMethod !== undefined && native.extractedLines === undefined
-    ? { status: 'unobserved', reason: `The selected ${input.lineMethod} line extraction is absent.` }
-    : predictedLineCount === expectedLineCount
-      ? { status: 'pass' }
-      : { status: 'fail', detail: `Predicted ${predictedLineCount} lines; native ${input.lineMethod ?? 'block'} observation has ${expectedLineCount}.` }
-  const unextracted: MetricResult = { status: 'unobserved', reason: 'No source line-boundary extraction was selected.' }
+  let lineCount: MetricResult = predictedLineCount === native.lineCount
+    ? { status: 'pass' }
+    : { status: 'fail', detail: `Predicted ${predictedLineCount} lines; native block observation has ${native.lineCount}.` }
+  let breaks: MetricResult = { status: 'unobserved', reason: 'No source line-boundary extraction was selected.' }
+  if (input.lineMethod !== undefined) {
+    const extraction = native.extraction
+    if (extraction === undefined) {
+      lineCount = breaks = { status: 'unobserved', reason: `The selected ${input.lineMethod} extraction has no stage geometry. Legacy source groups cannot establish its height or source ownership.` }
+    } else if (extraction.method !== input.lineMethod || extraction.source !== normalizeSource(input.text, input.whiteSpace)) {
+      lineCount = breaks = { status: 'unobserved', reason: 'The recorded extraction method or source differs from the selected observation protocol.' }
+    } else {
+      const count = extractionLineCount(extraction)
+      if (count === null) {
+        lineCount = breaks = { status: 'unobserved', reason: 'Extraction-stage height and resolved line-height do not establish an integral line-box count.' }
+      } else {
+        lineCount = predictedLineCount === count
+          ? { status: 'pass' }
+          : { status: 'fail', detail: `Predicted ${predictedLineCount} lines; the ${extraction.method} extraction's own height ${extraction.height} establishes ${count}.` }
+        if (prediction.detail === 'full') breaks = compareExtractedBreaks(extraction, count, input.whiteSpace, prediction)
+      }
+    }
+  }
   let richHeight: MetricResult = { status: 'not-applicable', reason: 'No native inline-item protocol was selected.' }
   if (input.nativeItems === true) {
     richHeight = native.richHeight === undefined || prediction.detail !== 'full' || prediction.richLineCount === undefined
@@ -357,7 +489,7 @@ export function assess(
   }
   if (prediction.detail === 'height') {
     const unobserved: MetricResult = { status: 'unobserved', reason: 'This maintained case is scheduled for height observation only.' }
-    return { height, lineCount, breaks: unextracted, source: unobserved, whitespace: unobserved, widths: unobserved, hyphen: input.text.includes('\u00ad') ? unobserved : { status: 'not-applicable', reason: 'No soft hyphen.' }, api: unobserved, richHeight }
+    return { height, lineCount, breaks, source: unobserved, whitespace: unobserved, widths: unobserved, hyphen: input.text.includes('\u00ad') ? unobserved : { status: 'not-applicable', reason: 'No soft hyphen.' }, api: unobserved, richHeight }
   }
   const observedInput = input.nativeSource === 'normalized' ? { ...input, text: normalizeSource(input.text, input.whiteSpace) } : input
   const spans = sourceSpans(observedInput)
@@ -371,19 +503,6 @@ export function assess(
   const whitespace = browser === 'safari' && input.whiteSpace === 'pre-wrap' && /[ \t]/.test(input.text)
     ? { status: 'unobserved' as const, reason: 'Safari pre-wrap whitespace Range ownership requires an independent span cross-check.' }
     : compareSource(observedInput, native, prediction.lines, spans, true)
-  let breaks: MetricResult = unextracted
-  if (native.extractedLines !== undefined) {
-    breaks = { status: 'pass' }
-    for (let index = 0; index < Math.max(prediction.lines.length, native.extractedLines.length); index++) {
-      const actual = prediction.lines[index]
-      const expected = native.extractedLines[index]
-      const end = actual === undefined ? -1 : actual.sourceStart + prediction.normalized.slice(actual.sourceStart, actual.sourceEnd).trimEnd().length
-      if (actual === undefined || expected === undefined || actual.sourceStart !== expected.start || end !== expected.end) {
-        breaks = { status: 'fail', detail: `Line ${index}: predicted source [${actual?.sourceStart ?? -1}, ${end}), native ${input.lineMethod} [${expected?.start ?? -1}, ${expected?.end ?? -1}).` }
-        break
-      }
-    }
-  }
   return {
     height, lineCount, breaks, source, whitespace, richHeight,
     widths: compareWidths(input, native, prediction.lines),

--- a/tests/wrapping/types.ts
+++ b/tests/wrapping/types.ts
@@ -56,12 +56,27 @@ export type Assessment = {
 
 export type NativeRect = { x: number; y: number; width: number; height: number }
 export type NativePoint = { start: number; end: number; text: string; rects: NativeRect[] }
+export type NativeExtraction = {
+  method: 'range' | 'span'
+  // The exact documented-normalized source laid out by this intervention.
+  source: string
+  height: number
+  usedLineHeight: number
+  units: NativePoint[]
+  // Scalar rectangles inside the same extraction DOM retain visible evidence
+  // even when a grapheme unit also contains an invisible formatting control.
+  points: NativePoint[]
+  lineRects: NativeRect[]
+}
 export type NativeObservation = {
   height: number
   lineCount: number
   usedLineHeight?: number
   points: NativePoint[]
   lineRects: NativeRect[]
+  extraction?: NativeExtraction
+  // Observer v1 source groups lack extraction-stage geometry. Retained only
+  // for reading old records; they cannot reconstruct a NativeExtraction.
   extractedLines?: Array<{ start: number; end: number }>
   richHeight?: number
 }
@@ -106,7 +121,7 @@ export type BrowserEnvironment = {
 
 export type BrowserReport = {
   status: 'ready'
-  observerVersion: 1
+  observerVersion: 2
   contexts: Array<Extract<BrowserContext, { kind: 'installed' }>>
   rowCount: number
   environment: BrowserEnvironment


### PR DESCRIPTION
Complex streaming, statistics and batch APIs could choose different boundaries after a soft hyphen. They now share one complex line walker, with consistent priority for later fitting breaks and correct progress across consecutive consumed-only chunks. The simple fast path, preparation and public API remain unchanged; runtime source shrinks by 266 lines.

The wrapping observer also retains each selected extraction's own source and geometry. It measures line count independently of ambiguous source ownership and preserves established LF and whitespace boundaries. This fixes false test assessments without changing library output. The broader source-boundary experiments remain excluded; #210 and #211 remain open.

Validation:
- Full native comparisons cover 656,402 inputs in Chrome, Safari and Firefox: 19,054 API disagreements repaired, no lost native accuracy successes, and unchanged batch line output.
- Final ordinary checks pass on 33,622 inputs plus nine numeric profiles. All 84 selected full extraction records and their final assessments match the fresh ordinary run.
- 181 unit tests / 1,119 assertions, TypeScript/lint/Knip, package consumers and static site checks pass. Docs, snapshots and dashboards are updated.
- Foreground benchmarks stay close for ordinary/Arabic layout. Pre-wrap stats improve; range walking rises from 0.125 to 0.145 ms in Chrome and 0.150 to 0.200 ms in Safari per stress batch. These costs are accepted for this merge.

Preserve the commits with a merge commit: the wrapping baseline intentionally references reviewed runtime 2b73992.
