### PR TITLE
Fix broken preloads in the bubbles demo

### DIFF
--- a/pages/demos/bubbles.html
+++ b/pages/demos/bubbles.html
@@ -4,8 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Shrinkwrap Showdown</title>
-<link rel="modulepreload" href="./bubbles-shared.ts">
-<link rel="modulepreload" href="../../src/layout.ts">
+<script type="module" src="./bubbles.ts"></script>
 <script>
   (function syncInitialBubbleGeometry() {
     const root = document.documentElement
@@ -353,6 +352,5 @@
       shrinkWaste.textContent = '0'
     })()
   </script>
-  <script type="module" src="./bubbles.ts"></script>
 </body>
 </html>


### PR DESCRIPTION
The bubbles demo preloads `bubbles-shared.ts` and `src/layout.ts` directly. `bun run site:build` leaves those URLs in the generated HTML, but both modules are bundled into the demo's JavaScript and neither source file exists in the static output. Visiting the published demo therefore requests two missing files.

Move the existing module entry to the head and remove the source-file preload hints. The entry starts loading early, still executes after HTML parsing, and Bun rewrites it to the emitted JavaScript bundle.

Validation: `bun run site:build`, `bun run check`, and `git diff --check` pass. All 19 local links across the 10 generated HTML pages resolve. Headless Chrome smoke checks pass for the development page and static output served under `/pretext/`, at 1200px and 375px widths: the seven messages render, the slider updates the layout, and there are no failed resource requests or page errors.
