### PR TITLE
Simplify prepare state without changing output

### DIFF
--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -160,28 +160,28 @@ The bracket carry also kept CJK line-start prohibitions that `kinsokuStart` did
 not list, such as `〟`, `］`, `｡`, `〜` or `゛`, with the bracket. The check now covers
 every code point in Pretext's CJK ranges whose UAX #14 class forbids a break
 before it, from the generated class table: CL, EX, NS and the non-extending CM
-U+3035. `Intl.Segmenter` joins
-some nonstarters, such as `゛` or `ヽ`, with the kana after them, so a piece's
-first code point decides whether it attaches to the preceding text. U+3000 is BA,
-but Chromium and Firefox hang or trim it at a line end, so it needs its own
-line-end model rather than a kinsoku entry. Chromium's rules for Chinese pages
-also allow a break before `〜` and `゠`, which Pretext does not model yet. U+30FC
-is CJ, so the engine profile decides it rather than the set; see Content
-Language.
+U+3035. `Intl.Segmenter` joins some nonstarters, such as `゛` or `ヽ`, with the kana
+after them, so a piece's first code point decides whether it attaches to the
+preceding text. U+3000 is BA, but Chromium and Firefox hang or trim it at a line
+end, so it needs its own line-end model rather than a kinsoku entry. Chromium's
+rules for Chinese pages also allow a break before `〜` and `゠`, which Pretext does
+not model yet. U+30FC is CJ, so the engine profile decides it rather than the
+class check; see Content Language.
 
 Under `word-break: keep-all`, Blink keeps a pair only when both sides are letters
 or numbers by general category and neither is SA. It tests UTF-16 code units and
 looks past one combining mark before the boundary, so it never keeps a symbol or a
 supplementary character, and it leaves every other pair to ICU's ordinary rules.
-So a listed letter such as `々`, `ゝ`, `〼`, `〵` or `ー` does not end a run in the
-Chromium profile, while punctuation such as `」`, `・` or `゛` does. Gecko's ICU4X
-keeps pairs by line-break class instead (AI, AL, ID, NU, HY, the Hangul classes and
-CJ), where a mark takes its base's class. It keeps `ー`, symbols such as `★`,
-supplementary ideographs and, after an ideograph, `〵` or an ideographic variation
-selector, but breaks after NS letters such as `々` or `〼`, and after `〵` following
-a closing bracket. `keepAllPairModel` picks Blink's rule, ICU4X's, or WebKit's,
-whose keep-all breaks only at spaces; newer WebKit source also breaks after opening,
-closing and other punctuation there, but not after letters.
+So a letter that cannot start a line, such as `々`, `ゝ`, `〼`, `〵` or `ー`, does not
+end a run in the Chromium profile, while punctuation such as `」`, `・` or `゛` does.
+Gecko's ICU4X keeps pairs by line-break class instead (AI, AL, ID, NU, HY, the
+Hangul classes and CJ), where a mark takes its base's class. It keeps `ー`, symbols
+such as `★`, supplementary ideographs and, after an ideograph, `〵` or an
+ideographic variation selector, but breaks after NS letters such as `々` or `〼`,
+and after `〵` following a closing bracket. `keepAllPairModel` picks Blink's rule,
+ICU4X's, or WebKit's, whose keep-all breaks only at spaces; newer WebKit source
+also breaks after opening, closing and other punctuation there, but not after
+letters.
 
 Where the engine does not keep a pair, Pretext ends a keep-all run where UAX #14
 allows a break between the two line-break classes. The classes come from a table

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -157,9 +157,10 @@ characters (`文”|文`), though not after `.”` before Hangul. Chromium's ICU
 Chinese pages treat `”` as CL and break there too (`다.”|라|고`).
 
 The bracket carry also kept CJK line-start prohibitions that `kinsokuStart` did
-not list, such as `〟`, `］`, `｡`, `〜` or `゛`, with the bracket. The set now holds
+not list, such as `〟`, `］`, `｡`, `〜` or `゛`, with the bracket. The check now covers
 every code point in Pretext's CJK ranges whose UAX #14 class forbids a break
-before it: CL, EX, NS and the non-extending CM U+3035. `Intl.Segmenter` joins
+before it, from the generated class table: CL, EX, NS and the non-extending CM
+U+3035. `Intl.Segmenter` joins
 some nonstarters, such as `゛` or `ヽ`, with the kana after them, so a piece's
 first code point decides whether it attaches to the preceding text. U+3000 is BA,
 but Chromium and Firefox hang or trim it at a line end, so it needs its own

--- a/accuracy/chrome.json
+++ b/accuracy/chrome.json
@@ -1,19 +1,19 @@
 {
-  "generatedAt": "2026-09-13T06:12:54.772Z",
-  "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+  "generatedAt": "2026-09-13T10:44:29.917Z",
+  "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
   "source": {
-    "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+    "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
     "files": {
-      "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+      "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
       "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
       "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
       "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
       "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-      "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-      "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-      "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-      "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-      "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+      "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+      "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+      "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+      "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+      "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
       "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
     }
   },

--- a/accuracy/firefox.json
+++ b/accuracy/firefox.json
@@ -1,19 +1,19 @@
 {
-  "generatedAt": "2026-09-13T06:12:54.772Z",
-  "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+  "generatedAt": "2026-09-13T10:44:29.917Z",
+  "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
   "source": {
-    "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+    "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
     "files": {
-      "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+      "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
       "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
       "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
       "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
       "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-      "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-      "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-      "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-      "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-      "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+      "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+      "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+      "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+      "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+      "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
       "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
     }
   },

--- a/accuracy/letter-spacing.json
+++ b/accuracy/letter-spacing.json
@@ -1,19 +1,19 @@
 {
-  "generatedAt": "2026-09-13T06:12:54.772Z",
-  "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+  "generatedAt": "2026-09-13T10:44:29.917Z",
+  "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
   "source": {
-    "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+    "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
     "files": {
-      "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+      "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
       "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
       "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
       "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
       "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-      "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-      "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-      "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-      "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-      "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+      "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+      "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+      "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+      "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+      "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
       "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
     }
   },
@@ -307,7 +307,7 @@
           "screenAvailWidth": 2560,
           "screenAvailHeight": 1315,
           "visibility": "visible",
-          "focused": false,
+          "focused": true,
           "language": "en",
           "direction": "ltr"
         },
@@ -325,7 +325,7 @@
           "screenAvailWidth": 2560,
           "screenAvailHeight": 1315,
           "visibility": "visible",
-          "focused": false,
+          "focused": true,
           "language": "en",
           "direction": "ltr"
         },
@@ -339,7 +339,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": false,
+      "focused": true,
       "fonts": []
     },
     {
@@ -361,7 +361,7 @@
           "screenAvailWidth": 2560,
           "screenAvailHeight": 1315,
           "visibility": "visible",
-          "focused": false,
+          "focused": true,
           "language": "he",
           "direction": "ltr"
         },
@@ -379,7 +379,7 @@
           "screenAvailWidth": 2560,
           "screenAvailHeight": 1315,
           "visibility": "visible",
-          "focused": false,
+          "focused": true,
           "language": "he",
           "direction": "ltr"
         },
@@ -393,7 +393,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": false,
+      "focused": true,
       "fonts": []
     },
     {
@@ -415,7 +415,7 @@
           "screenAvailWidth": 2560,
           "screenAvailHeight": 1315,
           "visibility": "visible",
-          "focused": false,
+          "focused": true,
           "language": "ja",
           "direction": "ltr"
         },
@@ -433,7 +433,7 @@
           "screenAvailWidth": 2560,
           "screenAvailHeight": 1315,
           "visibility": "visible",
-          "focused": false,
+          "focused": true,
           "language": "ja",
           "direction": "ltr"
         },
@@ -447,7 +447,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": false,
+      "focused": true,
       "fonts": []
     },
     {
@@ -469,7 +469,7 @@
           "screenAvailWidth": 2560,
           "screenAvailHeight": 1315,
           "visibility": "visible",
-          "focused": false,
+          "focused": true,
           "language": "zh",
           "direction": "ltr"
         },
@@ -487,7 +487,7 @@
           "screenAvailWidth": 2560,
           "screenAvailHeight": 1315,
           "visibility": "visible",
-          "focused": false,
+          "focused": true,
           "language": "zh",
           "direction": "ltr"
         },
@@ -501,7 +501,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": false,
+      "focused": true,
       "fonts": []
     },
     {
@@ -523,7 +523,7 @@
           "screenAvailWidth": 2560,
           "screenAvailHeight": 1315,
           "visibility": "visible",
-          "focused": false,
+          "focused": true,
           "language": "ar",
           "direction": "rtl"
         },
@@ -541,7 +541,7 @@
           "screenAvailWidth": 2560,
           "screenAvailHeight": 1315,
           "visibility": "visible",
-          "focused": false,
+          "focused": true,
           "language": "ar",
           "direction": "rtl"
         },
@@ -555,7 +555,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": false,
+      "focused": true,
       "fonts": []
     }
   ],

--- a/accuracy/safari.json
+++ b/accuracy/safari.json
@@ -1,19 +1,19 @@
 {
-  "generatedAt": "2026-09-13T06:12:54.772Z",
-  "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+  "generatedAt": "2026-09-13T10:44:29.917Z",
+  "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
   "source": {
-    "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+    "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
     "files": {
-      "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+      "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
       "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
       "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
       "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
       "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-      "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-      "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-      "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-      "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-      "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+      "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+      "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+      "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+      "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+      "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
       "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
     }
   },
@@ -36,7 +36,7 @@
           "screenAvailWidth": 2560,
           "screenAvailHeight": 1315,
           "visibility": "visible",
-          "focused": false,
+          "focused": true,
           "language": "en",
           "direction": "ltr"
         },
@@ -54,7 +54,7 @@
           "screenAvailWidth": 2560,
           "screenAvailHeight": 1315,
           "visibility": "visible",
-          "focused": false,
+          "focused": true,
           "language": "en",
           "direction": "ltr"
         },
@@ -68,7 +68,7 @@
       "dpr": 2,
       "locale": "zh-CN",
       "visibility": "visible",
-      "focused": false,
+      "focused": true,
       "fonts": []
     }
   ],

--- a/benchmarks/chrome.json
+++ b/benchmarks/chrome.json
@@ -3,7 +3,7 @@
   "runs": [
     {
       "status": "ready",
-      "requestId": "1789283671555-0-vc1xz0g9dsk",
+      "requestId": "1789295988256-0-myj4xrwf6xc",
       "environment": {
         "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/153.0.0.0 Safari/537.36",
         "start": {
@@ -55,10 +55,10 @@
           "breakableSegments": 0,
           "width": 300,
           "lineCount": 193,
-          "analysisMs": 1.2000000476837158,
-          "measureMs": 2.100000023841858,
-          "prepareMs": 3.399999976158142,
-          "layoutMs": 0.01399999976158142
+          "analysisMs": 1.100000023841858,
+          "measureMs": 1.9999998807907104,
+          "prepareMs": 3.100000023841858,
+          "layoutMs": 0.01300000011920929
         },
         {
           "id": "ja-rashomon",
@@ -70,10 +70,10 @@
           "breakableSegments": 6,
           "width": 300,
           "lineCount": 380,
-          "analysisMs": 2.5,
-          "measureMs": 4.200000047683716,
-          "prepareMs": 6.700000047683716,
-          "layoutMs": 0.0275
+          "analysisMs": 2.399999976158142,
+          "measureMs": 3.700000047683716,
+          "prepareMs": 6.100000023841858,
+          "layoutMs": 0.025
         },
         {
           "id": "ko-unsu-joh-eun-nal",
@@ -85,10 +85,10 @@
           "breakableSegments": 3,
           "width": 300,
           "lineCount": 428,
-          "analysisMs": 1.6999999284744263,
-          "measureMs": 4.0000001192092896,
-          "prepareMs": 5.700000047683716,
-          "layoutMs": 0.05199999988079071
+          "analysisMs": 1.5999999046325684,
+          "measureMs": 3.700000047683716,
+          "prepareMs": 5.299999952316284,
+          "layoutMs": 0.05100000023841858
         },
         {
           "id": "ko-sonagi",
@@ -100,10 +100,10 @@
           "breakableSegments": 3,
           "width": 300,
           "lineCount": 332,
-          "analysisMs": 1.2999999523162842,
-          "measureMs": 3.299999952316284,
-          "prepareMs": 4.5,
-          "layoutMs": 0.03899999976158142
+          "analysisMs": 1.1999999284744263,
+          "measureMs": 2.8000000715255737,
+          "prepareMs": 4,
+          "layoutMs": 0.0375
         },
         {
           "id": "zh-zhufu",
@@ -115,10 +115,10 @@
           "breakableSegments": 2,
           "width": 300,
           "lineCount": 626,
-          "analysisMs": 3.899999976158142,
-          "measureMs": 7,
-          "prepareMs": 11,
-          "layoutMs": 0.0425
+          "analysisMs": 3.5,
+          "measureMs": 6.200000047683716,
+          "prepareMs": 9.700000047683716,
+          "layoutMs": 0.04150000035762787
         },
         {
           "id": "zh-guxiang",
@@ -130,10 +130,10 @@
           "breakableSegments": 14,
           "width": 300,
           "lineCount": 375,
-          "analysisMs": 2.299999952316284,
-          "measureMs": 3.899999976158142,
-          "prepareMs": 6.199999928474426,
-          "layoutMs": 0.02599999964237213
+          "analysisMs": 2.200000047683716,
+          "measureMs": 3.5,
+          "prepareMs": 5.600000023841858,
+          "layoutMs": 0.02400000035762787
         },
         {
           "id": "th-nithan-vetal-story-1",
@@ -145,10 +145,10 @@
           "breakableSegments": 8087,
           "width": 300,
           "lineCount": 1024,
-          "analysisMs": 6.300000071525574,
-          "measureMs": 4.300000071525574,
-          "prepareMs": 10.699999928474426,
-          "layoutMs": 0.056999999880790714
+          "analysisMs": 6.100000023841858,
+          "measureMs": 3.9000000953674316,
+          "prepareMs": 9.900000095367432,
+          "layoutMs": 0.055
         },
         {
           "id": "my-cunning-heron-teacher",
@@ -163,7 +163,7 @@
           "analysisMs": 0.5,
           "measureMs": 0.3999999761581421,
           "prepareMs": 0.8999999761581421,
-          "layoutMs": 0.0035000002384185792
+          "layoutMs": 0.003999999761581421
         },
         {
           "id": "my-bad-deeds-return-to-you-teacher",
@@ -176,9 +176,9 @@
           "width": 300,
           "lineCount": 54,
           "analysisMs": 0.2999999523162842,
-          "measureMs": 0.39999985694885254,
-          "prepareMs": 0.6999999284744263,
-          "layoutMs": 0.0025
+          "measureMs": 0.30000007152557373,
+          "prepareMs": 0.6000000238418579,
+          "layoutMs": 0.0020000004768371583
         },
         {
           "id": "ur-chughd",
@@ -190,10 +190,10 @@
           "breakableSegments": 2920,
           "width": 300,
           "lineCount": 352,
-          "analysisMs": 1.899999976158142,
-          "measureMs": 2.3000000715255737,
-          "prepareMs": 4.199999928474426,
-          "layoutMs": 0.025
+          "analysisMs": 1.6999999284744263,
+          "measureMs": 2.0999999046325684,
+          "prepareMs": 3.700000047683716,
+          "layoutMs": 0.02399999976158142
         },
         {
           "id": "km-prachum-reuang-preng-khmer-volume-7-stories-1-10",
@@ -205,10 +205,10 @@
           "breakableSegments": 3547,
           "width": 300,
           "lineCount": 591,
-          "analysisMs": 3.600000023841858,
-          "measureMs": 3.5999999046325684,
-          "prepareMs": 7.200000047683716,
-          "layoutMs": 0.05549999952316284
+          "analysisMs": 3.5,
+          "measureMs": 3.399999976158142,
+          "prepareMs": 7,
+          "layoutMs": 0.0525
         },
         {
           "id": "hi-eidgah",
@@ -220,10 +220,10 @@
           "breakableSegments": 4089,
           "width": 300,
           "lineCount": 653,
-          "analysisMs": 2.8000000715255737,
-          "measureMs": 4.299999833106995,
-          "prepareMs": 7.100000023841858,
-          "layoutMs": 0.04350000023841858
+          "analysisMs": 2.700000047683716,
+          "measureMs": 4.099999904632568,
+          "prepareMs": 6.800000071525574,
+          "layoutMs": 0.04150000035762787
         },
         {
           "id": "synthetic-long-breakable-runs",
@@ -235,10 +235,10 @@
           "breakableSegments": 1540,
           "width": 300,
           "lineCount": 2860,
-          "analysisMs": 3.399999976158142,
-          "measureMs": 6.699999928474426,
-          "prepareMs": 10.100000023841858,
-          "layoutMs": 0.2714999997615814
+          "analysisMs": 3.1999999284744263,
+          "measureMs": 6.200000166893005,
+          "prepareMs": 9.700000047683716,
+          "layoutMs": 0.26149999976158145
         },
         {
           "id": "ar-risalat-al-ghufran-part-1",
@@ -251,31 +251,31 @@
           "width": 300,
           "lineCount": 2643,
           "analysisMs": 11.5,
-          "measureMs": 34.200000047683716,
-          "prepareMs": 45.60000002384186,
-          "layoutMs": 0.1725
+          "measureMs": 30.59999990463257,
+          "prepareMs": 41.89999997615814,
+          "layoutMs": 0.17
         }
       ],
       "results": [
         {
           "label": "Our library: prepare()",
           "desc": "One cold 500-text measurement batch",
-          "ms": 9.699999988079071
+          "ms": 9.25
         },
         {
           "label": "Our library: layout()",
           "desc": "Normalized hot-path throughput per 500-text batch",
-          "ms": 0.09149999976158142
+          "ms": 0.08825000017881393
         },
         {
           "label": "DOM batch",
           "desc": "Single 400→300px batch resize: write all, then read all",
-          "ms": 2.400000035762787
+          "ms": 2.399999976158142
         },
         {
           "label": "DOM interleaved",
           "desc": "Single 400→300px batch resize: write + read per div",
-          "ms": 27.649999976158142
+          "ms": 27.25
         }
       ],
       "richResults": [
@@ -287,17 +287,17 @@
         {
           "label": "Our library: layoutWithLines()",
           "desc": "60-text shared-corpus batch across widths 180/220/260px; materializes text lines",
-          "ms": 0.032500000298023225
+          "ms": 0.032499998807907104
         },
         {
           "label": "Our library: walkLineRanges()",
           "desc": "60-text shared-corpus batch across widths 180/220/260px; line ranges only, no line text strings",
-          "ms": 0.015000000596046448
+          "ms": 0.016249999403953552
         },
         {
           "label": "Our library: layoutNextLine()",
           "desc": "60-text shared-corpus batch across widths 180/220/260px; streaming line-by-line layout",
-          "ms": 0.02750000059604645
+          "ms": 0.026250000298023227
         }
       ],
       "richInlineResults": [
@@ -314,62 +314,62 @@
         {
           "label": "Our library: materializeRichInlineLineRange()",
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; range walker plus per-line materialization",
-          "ms": 0.02749999761581421
+          "ms": 0.025
         },
         {
           "label": "Our library: layoutNextRichInlineLineRange() + materializeRichInlineLineRange()",
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; streaming range walk plus per-line materialization",
-          "ms": 0.023749999701976776
+          "ms": 0.02250000089406967
         }
       ],
       "richPreWrapResults": [
         {
           "label": "Our library: measureLineStats()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only",
-          "ms": 0.1375
+          "ms": 0.125
         },
         {
           "label": "Our library: layoutWithLines()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; materializes text lines",
-          "ms": 0.275
+          "ms": 0.2649999976158142
         },
         {
           "label": "Our library: walkLineRanges()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; line ranges only, no line text strings",
-          "ms": 0.1524999976158142
+          "ms": 0.14000000059604645
         },
         {
           "label": "Our library: layoutNextLine()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; streaming line-by-line layout",
-          "ms": 0.5949999988079071
+          "ms": 0.5975000023841858
         }
       ],
       "richLongResults": [
         {
           "label": "Our library: measureLineStats()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; stats only",
-          "ms": 0.89375
+          "ms": 0.8950000002980232
         },
         {
           "label": "Our library: layoutWithLines()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines",
-          "ms": 3.4337500020861627
+          "ms": 3.370000000298023
         },
         {
           "label": "Our library: walkLineRanges()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; line ranges only, no line text strings",
-          "ms": 1.401250000298023
+          "ms": 1.3899999991059304
         },
         {
           "label": "Our library: layoutNextLine()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout",
-          "ms": 3.0099999994039535
+          "ms": 2.9875
         }
       ]
     },
     {
       "status": "ready",
-      "requestId": "1789283681033-1-p5q3er1pt9",
+      "requestId": "1789295997664-1-ir1mtpz0le",
       "environment": {
         "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/153.0.0.0 Safari/537.36",
         "start": {
@@ -422,9 +422,9 @@
           "width": 300,
           "lineCount": 193,
           "analysisMs": 1.2000000476837158,
-          "measureMs": 2.1999999284744263,
-          "prepareMs": 3.399999976158142,
-          "layoutMs": 0.01399999976158142
+          "measureMs": 2.0000001192092896,
+          "prepareMs": 3.299999952316284,
+          "layoutMs": 0.01350000023841858
         },
         {
           "id": "ja-rashomon",
@@ -436,10 +436,10 @@
           "breakableSegments": 6,
           "width": 300,
           "lineCount": 380,
-          "analysisMs": 2.5,
-          "measureMs": 4.5,
-          "prepareMs": 6.899999976158142,
-          "layoutMs": 0.02550000011920929
+          "analysisMs": 2.4000000953674316,
+          "measureMs": 4.100000023841858,
+          "prepareMs": 6.300000071525574,
+          "layoutMs": 0.02700000047683716
         },
         {
           "id": "ko-unsu-joh-eun-nal",
@@ -451,9 +451,9 @@
           "breakableSegments": 3,
           "width": 300,
           "lineCount": 428,
-          "analysisMs": 1.7000000476837158,
-          "measureMs": 4.299999952316284,
-          "prepareMs": 6,
+          "analysisMs": 1.600000023841858,
+          "measureMs": 4,
+          "prepareMs": 5.700000047683716,
           "layoutMs": 0.0525
         },
         {
@@ -466,10 +466,10 @@
           "breakableSegments": 3,
           "width": 300,
           "lineCount": 332,
-          "analysisMs": 1.399999976158142,
-          "measureMs": 3.299999952316284,
-          "prepareMs": 4.700000047683716,
-          "layoutMs": 0.04
+          "analysisMs": 1.2999999523162842,
+          "measureMs": 3.200000047683716,
+          "prepareMs": 4.5,
+          "layoutMs": 0.03949999988079071
         },
         {
           "id": "zh-zhufu",
@@ -481,10 +481,10 @@
           "breakableSegments": 2,
           "width": 300,
           "lineCount": 626,
-          "analysisMs": 3.799999952316284,
-          "measureMs": 6.799999952316284,
-          "prepareMs": 10.600000023841858,
-          "layoutMs": 0.04300000011920929
+          "analysisMs": 3.600000023841858,
+          "measureMs": 6.199999928474426,
+          "prepareMs": 10,
+          "layoutMs": 0.04149999976158142
         },
         {
           "id": "zh-guxiang",
@@ -496,10 +496,10 @@
           "breakableSegments": 14,
           "width": 300,
           "lineCount": 375,
-          "analysisMs": 2.200000047683716,
-          "measureMs": 4.200000047683716,
-          "prepareMs": 6.399999976158142,
-          "layoutMs": 0.02599999964237213
+          "analysisMs": 2.100000023841858,
+          "measureMs": 3.600000023841858,
+          "prepareMs": 5.699999928474426,
+          "layoutMs": 0.02600000023841858
         },
         {
           "id": "th-nithan-vetal-story-1",
@@ -511,9 +511,9 @@
           "breakableSegments": 8087,
           "width": 300,
           "lineCount": 1024,
-          "analysisMs": 6.199999928474426,
-          "measureMs": 4.5000001192092896,
-          "prepareMs": 10.600000023841858,
+          "analysisMs": 6.200000047683716,
+          "measureMs": 3.600000023841858,
+          "prepareMs": 9.800000071525574,
           "layoutMs": 0.056999999880790714
         },
         {
@@ -527,9 +527,9 @@
           "width": 300,
           "lineCount": 81,
           "analysisMs": 0.5,
-          "measureMs": 0.3999999761581421,
-          "prepareMs": 0.9000000953674316,
-          "layoutMs": 0.004000000357627868
+          "measureMs": 0.49999988079071045,
+          "prepareMs": 0.8999999761581421,
+          "layoutMs": 0.003999999761581421
         },
         {
           "id": "my-bad-deeds-return-to-you-teacher",
@@ -541,9 +541,9 @@
           "breakableSegments": 273,
           "width": 300,
           "lineCount": 54,
-          "analysisMs": 0.30000007152557373,
-          "measureMs": 0.30000007152557373,
-          "prepareMs": 0.6000000238418579,
+          "analysisMs": 0.2999999523162842,
+          "measureMs": 0.40000009536743164,
+          "prepareMs": 0.6999999284744263,
           "layoutMs": 0.0025
         },
         {
@@ -556,9 +556,9 @@
           "breakableSegments": 2920,
           "width": 300,
           "lineCount": 352,
-          "analysisMs": 1.7999999523162842,
-          "measureMs": 2.3000000715255737,
-          "prepareMs": 4.100000023841858,
+          "analysisMs": 1.8000000715255737,
+          "measureMs": 2.100000023841858,
+          "prepareMs": 4,
           "layoutMs": 0.025
         },
         {
@@ -571,10 +571,10 @@
           "breakableSegments": 3547,
           "width": 300,
           "lineCount": 591,
-          "analysisMs": 3.899999976158142,
-          "measureMs": 3.1999999284744263,
-          "prepareMs": 7,
-          "layoutMs": 0.05550000011920929
+          "analysisMs": 3.799999952316284,
+          "measureMs": 2.799999952316284,
+          "prepareMs": 6.5,
+          "layoutMs": 0.055
         },
         {
           "id": "hi-eidgah",
@@ -587,8 +587,8 @@
           "width": 300,
           "lineCount": 653,
           "analysisMs": 2.799999952316284,
-          "measureMs": 6.900000095367432,
-          "prepareMs": 9.800000071525574,
+          "measureMs": 3.9999998807907104,
+          "prepareMs": 6.799999952316284,
           "layoutMs": 0.04449999988079071
         },
         {
@@ -602,9 +602,9 @@
           "width": 300,
           "lineCount": 2860,
           "analysisMs": 3.299999952316284,
-          "measureMs": 6.599999904632568,
-          "prepareMs": 9.899999976158142,
-          "layoutMs": 0.2764999997615814
+          "measureMs": 6.5,
+          "prepareMs": 9.600000023841858,
+          "layoutMs": 0.2725
         },
         {
           "id": "ar-risalat-al-ghufran-part-1",
@@ -616,54 +616,54 @@
           "breakableSegments": 18759,
           "width": 300,
           "lineCount": 2643,
-          "analysisMs": 11.600000023841858,
-          "measureMs": 24.200000166893005,
-          "prepareMs": 36.5,
-          "layoutMs": 0.1625
+          "analysisMs": 11.800000071525574,
+          "measureMs": 19.799999952316284,
+          "prepareMs": 33.5,
+          "layoutMs": 0.1564999997615814
         }
       ],
       "results": [
         {
           "label": "Our library: prepare()",
           "desc": "One cold 500-text measurement batch",
-          "ms": 8.800000071525574
+          "ms": 8.399999976158142
         },
         {
           "label": "Our library: layout()",
           "desc": "Normalized hot-path throughput per 500-text batch",
-          "ms": 0.08850000023841859
+          "ms": 0.08675000011920929
         },
         {
           "label": "DOM batch",
           "desc": "Single 400→300px batch resize: write all, then read all",
-          "ms": 2.450000047683716
+          "ms": 2.449999988079071
         },
         {
           "label": "DOM interleaved",
           "desc": "Single 400→300px batch resize: write + read per div",
-          "ms": 34.950000047683716
+          "ms": 31.94999998807907
         }
       ],
       "richResults": [
         {
           "label": "Our library: measureLineStats()",
           "desc": "60-text shared-corpus batch across widths 180/220/260px; stats only",
-          "ms": 0.007500001788139343
+          "ms": 0.007499998807907105
         },
         {
           "label": "Our library: layoutWithLines()",
           "desc": "60-text shared-corpus batch across widths 180/220/260px; materializes text lines",
-          "ms": 0.030000001192092896
+          "ms": 0.03125000149011612
         },
         {
           "label": "Our library: walkLineRanges()",
           "desc": "60-text shared-corpus batch across widths 180/220/260px; line ranges only, no line text strings",
-          "ms": 0.015000000596046448
+          "ms": 0.01499999761581421
         },
         {
           "label": "Our library: layoutNextLine()",
           "desc": "60-text shared-corpus batch across widths 180/220/260px; streaming line-by-line layout",
-          "ms": 0.023750001192092897
+          "ms": 0.025
         }
       ],
       "richInlineResults": [
@@ -680,7 +680,7 @@
         {
           "label": "Our library: materializeRichInlineLineRange()",
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; range walker plus per-line materialization",
-          "ms": 0.026249998807907106
+          "ms": 0.025
         },
         {
           "label": "Our library: layoutNextRichInlineLineRange() + materializeRichInlineLineRange()",
@@ -692,50 +692,50 @@
         {
           "label": "Our library: measureLineStats()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only",
-          "ms": 0.13999999761581422
+          "ms": 0.125
         },
         {
           "label": "Our library: layoutWithLines()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; materializes text lines",
-          "ms": 0.2699999988079071
+          "ms": 0.2599999964237213
         },
         {
           "label": "Our library: walkLineRanges()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; line ranges only, no line text strings",
-          "ms": 0.15
+          "ms": 0.1449999988079071
         },
         {
           "label": "Our library: layoutNextLine()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; streaming line-by-line layout",
-          "ms": 0.5900000035762787
+          "ms": 0.5699999988079071
         }
       ],
       "richLongResults": [
         {
           "label": "Our library: measureLineStats()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; stats only",
-          "ms": 0.9237500011920929
+          "ms": 0.9225000008940696
         },
         {
           "label": "Our library: layoutWithLines()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines",
-          "ms": 3.3362499997019768
+          "ms": 3.373749999701977
         },
         {
           "label": "Our library: walkLineRanges()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; line ranges only, no line text strings",
-          "ms": 1.4174999997019766
+          "ms": 1.3987499997019768
         },
         {
           "label": "Our library: layoutNextLine()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout",
-          "ms": 2.988749998807907
+          "ms": 3.0562500000000004
         }
       ]
     },
     {
       "status": "ready",
-      "requestId": "1789283690483-2-1imkjrsi8qq",
+      "requestId": "1789296006914-2-pumoio1ewg",
       "environment": {
         "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/153.0.0.0 Safari/537.36",
         "start": {
@@ -788,8 +788,8 @@
           "width": 300,
           "lineCount": 193,
           "analysisMs": 1.1999999284744263,
-          "measureMs": 2.1999999284744263,
-          "prepareMs": 3.399999976158142,
+          "measureMs": 1.9999998807907104,
+          "prepareMs": 3.299999952316284,
           "layoutMs": 0.01399999976158142
         },
         {
@@ -802,10 +802,10 @@
           "breakableSegments": 6,
           "width": 300,
           "lineCount": 380,
-          "analysisMs": 2.4000000953674316,
-          "measureMs": 4.5,
-          "prepareMs": 6.899999976158142,
-          "layoutMs": 0.02649999976158142
+          "analysisMs": 2.5,
+          "measureMs": 4.300000071525574,
+          "prepareMs": 6.799999952316284,
+          "layoutMs": 0.0275
         },
         {
           "id": "ko-unsu-joh-eun-nal",
@@ -817,10 +817,10 @@
           "breakableSegments": 3,
           "width": 300,
           "lineCount": 428,
-          "analysisMs": 1.6999999284744263,
-          "measureMs": 4.299999833106995,
-          "prepareMs": 6.099999904632568,
-          "layoutMs": 0.05550000011920929
+          "analysisMs": 1.600000023841858,
+          "measureMs": 4.299999952316284,
+          "prepareMs": 5.899999976158142,
+          "layoutMs": 0.0525
         },
         {
           "id": "ko-sonagi",
@@ -832,10 +832,10 @@
           "breakableSegments": 3,
           "width": 300,
           "lineCount": 332,
-          "analysisMs": 1.399999976158142,
-          "measureMs": 3.5000001192092896,
-          "prepareMs": 4.900000095367432,
-          "layoutMs": 0.04
+          "analysisMs": 1.3000000715255737,
+          "measureMs": 3.1999998092651367,
+          "prepareMs": 4.599999904632568,
+          "layoutMs": 0.03949999988079071
         },
         {
           "id": "zh-zhufu",
@@ -847,10 +847,10 @@
           "breakableSegments": 2,
           "width": 300,
           "lineCount": 626,
-          "analysisMs": 3.899999976158142,
-          "measureMs": 6.799999952316284,
-          "prepareMs": 10.699999928474426,
-          "layoutMs": 0.0425
+          "analysisMs": 3.8000000715255737,
+          "measureMs": 6.799999833106995,
+          "prepareMs": 10.600000023841858,
+          "layoutMs": 0.04299999952316284
         },
         {
           "id": "zh-guxiang",
@@ -862,9 +862,9 @@
           "breakableSegments": 14,
           "width": 300,
           "lineCount": 375,
-          "analysisMs": 2.3000000715255737,
-          "measureMs": 4.399999976158142,
-          "prepareMs": 6.699999928474426,
+          "analysisMs": 2.200000047683716,
+          "measureMs": 3.9999998807907104,
+          "prepareMs": 6.199999928474426,
           "layoutMs": 0.02599999964237213
         },
         {
@@ -877,10 +877,10 @@
           "breakableSegments": 8087,
           "width": 300,
           "lineCount": 1024,
-          "analysisMs": 6.299999952316284,
-          "measureMs": 4.0000001192092896,
-          "prepareMs": 10.5,
-          "layoutMs": 0.05599999964237213
+          "analysisMs": 6.100000023841858,
+          "measureMs": 4.299999952316284,
+          "prepareMs": 10.299999952316284,
+          "layoutMs": 0.0575
         },
         {
           "id": "my-cunning-heron-teacher",
@@ -892,10 +892,10 @@
           "breakableSegments": 424,
           "width": 300,
           "lineCount": 81,
-          "analysisMs": 0.40000009536743164,
-          "measureMs": 0.5,
-          "prepareMs": 1,
-          "layoutMs": 0.003999999761581421
+          "analysisMs": 0.5,
+          "measureMs": 0.3999999761581421,
+          "prepareMs": 0.8999999761581421,
+          "layoutMs": 0.0044999998807907105
         },
         {
           "id": "my-bad-deeds-return-to-you-teacher",
@@ -923,9 +923,9 @@
           "width": 300,
           "lineCount": 352,
           "analysisMs": 1.7999999523162842,
-          "measureMs": 2.4000000953674316,
+          "measureMs": 2.200000047683716,
           "prepareMs": 4.200000047683716,
-          "layoutMs": 0.02550000011920929
+          "layoutMs": 0.02599999964237213
         },
         {
           "id": "km-prachum-reuang-preng-khmer-volume-7-stories-1-10",
@@ -939,8 +939,8 @@
           "lineCount": 591,
           "analysisMs": 3.600000023841858,
           "measureMs": 3.299999952316284,
-          "prepareMs": 7.100000023841858,
-          "layoutMs": 0.05449999988079071
+          "prepareMs": 6.899999976158142,
+          "layoutMs": 0.05550000011920929
         },
         {
           "id": "hi-eidgah",
@@ -952,10 +952,10 @@
           "breakableSegments": 4089,
           "width": 300,
           "lineCount": 653,
-          "analysisMs": 2.700000047683716,
-          "measureMs": 4.299999952316284,
-          "prepareMs": 6.900000095367432,
-          "layoutMs": 0.04449999988079071
+          "analysisMs": 2.8000000715255737,
+          "measureMs": 4.199999928474426,
+          "prepareMs": 7,
+          "layoutMs": 0.045
         },
         {
           "id": "synthetic-long-breakable-runs",
@@ -967,10 +967,10 @@
           "breakableSegments": 1540,
           "width": 300,
           "lineCount": 2860,
-          "analysisMs": 3.1999999284744263,
-          "measureMs": 6.4999998807907104,
-          "prepareMs": 9.899999976158142,
-          "layoutMs": 0.2819999998807907
+          "analysisMs": 3.299999952316284,
+          "measureMs": 6.800000071525574,
+          "prepareMs": 10.100000023841858,
+          "layoutMs": 0.2769999998807907
         },
         {
           "id": "ar-risalat-al-ghufran-part-1",
@@ -982,49 +982,49 @@
           "breakableSegments": 18759,
           "width": 300,
           "lineCount": 2643,
-          "analysisMs": 11.599999904632568,
+          "analysisMs": 11.300000071525574,
           "measureMs": 22.200000047683716,
-          "prepareMs": 34.40000009536743,
-          "layoutMs": 0.18800000011920928
+          "prepareMs": 33.60000002384186,
+          "layoutMs": 0.16299999952316285
         }
       ],
       "results": [
         {
           "label": "Our library: prepare()",
           "desc": "One cold 500-text measurement batch",
-          "ms": 9.150000035762787
+          "ms": 8.5
         },
         {
           "label": "Our library: layout()",
           "desc": "Normalized hot-path throughput per 500-text batch",
-          "ms": 0.08850000023841859
+          "ms": 0.08825000017881393
         },
         {
           "label": "DOM batch",
           "desc": "Single 400→300px batch resize: write all, then read all",
-          "ms": 2.150000035762787
+          "ms": 2.1999999284744263
         },
         {
           "label": "DOM interleaved",
           "desc": "Single 400→300px batch resize: write + read per div",
-          "ms": 27.25
+          "ms": 27.350000023841858
         }
       ],
       "richResults": [
         {
           "label": "Our library: measureLineStats()",
           "desc": "60-text shared-corpus batch across widths 180/220/260px; stats only",
-          "ms": 0.007500000298023224
+          "ms": 0.007500001788139343
         },
         {
           "label": "Our library: layoutWithLines()",
           "desc": "60-text shared-corpus batch across widths 180/220/260px; materializes text lines",
-          "ms": 0.029999999701976775
+          "ms": 0.030000001192092896
         },
         {
           "label": "Our library: walkLineRanges()",
           "desc": "60-text shared-corpus batch across widths 180/220/260px; line ranges only, no line text strings",
-          "ms": 0.0125
+          "ms": 0.014999999105930329
         },
         {
           "label": "Our library: layoutNextLine()",
@@ -1046,56 +1046,56 @@
         {
           "label": "Our library: materializeRichInlineLineRange()",
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; range walker plus per-line materialization",
-          "ms": 0.02750000059604645
+          "ms": 0.025
         },
         {
           "label": "Our library: layoutNextRichInlineLineRange() + materializeRichInlineLineRange()",
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; streaming range walk plus per-line materialization",
-          "ms": 0.023749999701976776
+          "ms": 0.02250000089406967
         }
       ],
       "richPreWrapResults": [
         {
           "label": "Our library: measureLineStats()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only",
-          "ms": 0.13999999761581422
+          "ms": 0.1300000011920929
         },
         {
           "label": "Our library: layoutWithLines()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; materializes text lines",
-          "ms": 0.2800000011920929
+          "ms": 0.2550000011920929
         },
         {
           "label": "Our library: walkLineRanges()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; line ranges only, no line text strings",
-          "ms": 0.1550000011920929
+          "ms": 0.14250000119209288
         },
         {
           "label": "Our library: layoutNextLine()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; streaming line-by-line layout",
-          "ms": 0.6049999982118606
+          "ms": 0.5799999982118607
         }
       ],
       "richLongResults": [
         {
           "label": "Our library: measureLineStats()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; stats only",
-          "ms": 0.8837500005960465
+          "ms": 0.9225000008940697
         },
         {
           "label": "Our library: layoutWithLines()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines",
-          "ms": 3.4674999997019764
+          "ms": 3.273750001192093
         },
         {
           "label": "Our library: walkLineRanges()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; line ranges only, no line text strings",
-          "ms": 1.4474999994039535
+          "ms": 1.4075000002980231
         },
         {
           "label": "Our library: layoutNextLine()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout",
-          "ms": 3.0599999994039537
+          "ms": 2.9200000002980233
         }
       ]
     }
@@ -1104,22 +1104,22 @@
     {
       "label": "Our library: prepare()",
       "desc": "One cold 500-text measurement batch",
-      "ms": 9.150000035762787
+      "ms": 8.5
     },
     {
       "label": "Our library: layout()",
       "desc": "Normalized hot-path throughput per 500-text batch",
-      "ms": 0.08850000023841859
+      "ms": 0.08825000017881393
     },
     {
       "label": "DOM batch",
       "desc": "Single 400→300px batch resize: write all, then read all",
-      "ms": 2.400000035762787
+      "ms": 2.399999976158142
     },
     {
       "label": "DOM interleaved",
       "desc": "Single 400→300px batch resize: write + read per div",
-      "ms": 27.649999976158142
+      "ms": 27.350000023841858
     }
   ],
   "richResults": [
@@ -1131,12 +1131,12 @@
     {
       "label": "Our library: layoutWithLines()",
       "desc": "60-text shared-corpus batch across widths 180/220/260px; materializes text lines",
-      "ms": 0.030000001192092896
+      "ms": 0.03125000149011612
     },
     {
       "label": "Our library: walkLineRanges()",
       "desc": "60-text shared-corpus batch across widths 180/220/260px; line ranges only, no line text strings",
-      "ms": 0.015000000596046448
+      "ms": 0.014999999105930329
     },
     {
       "label": "Our library: layoutNextLine()",
@@ -1158,56 +1158,56 @@
     {
       "label": "Our library: materializeRichInlineLineRange()",
       "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; range walker plus per-line materialization",
-      "ms": 0.02749999761581421
+      "ms": 0.025
     },
     {
       "label": "Our library: layoutNextRichInlineLineRange() + materializeRichInlineLineRange()",
       "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; streaming range walk plus per-line materialization",
-      "ms": 0.023749999701976776
+      "ms": 0.02250000089406967
     }
   ],
   "richPreWrapResults": [
     {
       "label": "Our library: measureLineStats()",
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only",
-      "ms": 0.13999999761581422
+      "ms": 0.125
     },
     {
       "label": "Our library: layoutWithLines()",
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; materializes text lines",
-      "ms": 0.275
+      "ms": 0.2599999964237213
     },
     {
       "label": "Our library: walkLineRanges()",
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; line ranges only, no line text strings",
-      "ms": 0.1524999976158142
+      "ms": 0.14250000119209288
     },
     {
       "label": "Our library: layoutNextLine()",
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; streaming line-by-line layout",
-      "ms": 0.5949999988079071
+      "ms": 0.5799999982118607
     }
   ],
   "richLongResults": [
     {
       "label": "Our library: measureLineStats()",
       "desc": "8 Arabic long-form texts across widths 240/300/360px; stats only",
-      "ms": 0.89375
+      "ms": 0.9225000008940696
     },
     {
       "label": "Our library: layoutWithLines()",
       "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines",
-      "ms": 3.4337500020861627
+      "ms": 3.370000000298023
     },
     {
       "label": "Our library: walkLineRanges()",
       "desc": "8 Arabic long-form texts across widths 240/300/360px; line ranges only, no line text strings",
-      "ms": 1.4174999997019766
+      "ms": 1.3987499997019768
     },
     {
       "label": "Our library: layoutNextLine()",
       "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout",
-      "ms": 3.0099999994039535
+      "ms": 2.9875
     }
   ],
   "corpusResults": [
@@ -1221,10 +1221,10 @@
       "breakableSegments": 0,
       "width": 300,
       "lineCount": 193,
-      "analysisMs": 1.2000000476837158,
-      "measureMs": 2.1999999284744263,
-      "prepareMs": 3.399999976158142,
-      "layoutMs": 0.01399999976158142
+      "analysisMs": 1.1999999284744263,
+      "measureMs": 1.9999998807907104,
+      "prepareMs": 3.299999952316284,
+      "layoutMs": 0.01350000023841858
     },
     {
       "id": "ja-rashomon",
@@ -1236,10 +1236,10 @@
       "breakableSegments": 6,
       "width": 300,
       "lineCount": 380,
-      "analysisMs": 2.5,
-      "measureMs": 4.5,
-      "prepareMs": 6.899999976158142,
-      "layoutMs": 0.02649999976158142
+      "analysisMs": 2.4000000953674316,
+      "measureMs": 4.100000023841858,
+      "prepareMs": 6.300000071525574,
+      "layoutMs": 0.02700000047683716
     },
     {
       "id": "ko-unsu-joh-eun-nal",
@@ -1251,9 +1251,9 @@
       "breakableSegments": 3,
       "width": 300,
       "lineCount": 428,
-      "analysisMs": 1.6999999284744263,
-      "measureMs": 4.299999833106995,
-      "prepareMs": 6,
+      "analysisMs": 1.600000023841858,
+      "measureMs": 4,
+      "prepareMs": 5.700000047683716,
       "layoutMs": 0.0525
     },
     {
@@ -1266,10 +1266,10 @@
       "breakableSegments": 3,
       "width": 300,
       "lineCount": 332,
-      "analysisMs": 1.399999976158142,
-      "measureMs": 3.299999952316284,
-      "prepareMs": 4.700000047683716,
-      "layoutMs": 0.04
+      "analysisMs": 1.2999999523162842,
+      "measureMs": 3.1999998092651367,
+      "prepareMs": 4.5,
+      "layoutMs": 0.03949999988079071
     },
     {
       "id": "zh-zhufu",
@@ -1281,10 +1281,10 @@
       "breakableSegments": 2,
       "width": 300,
       "lineCount": 626,
-      "analysisMs": 3.899999976158142,
-      "measureMs": 6.799999952316284,
-      "prepareMs": 10.699999928474426,
-      "layoutMs": 0.0425
+      "analysisMs": 3.600000023841858,
+      "measureMs": 6.200000047683716,
+      "prepareMs": 10,
+      "layoutMs": 0.04150000035762787
     },
     {
       "id": "zh-guxiang",
@@ -1296,9 +1296,9 @@
       "breakableSegments": 14,
       "width": 300,
       "lineCount": 375,
-      "analysisMs": 2.299999952316284,
-      "measureMs": 4.200000047683716,
-      "prepareMs": 6.399999976158142,
+      "analysisMs": 2.200000047683716,
+      "measureMs": 3.600000023841858,
+      "prepareMs": 5.699999928474426,
       "layoutMs": 0.02599999964237213
     },
     {
@@ -1311,9 +1311,9 @@
       "breakableSegments": 8087,
       "width": 300,
       "lineCount": 1024,
-      "analysisMs": 6.299999952316284,
-      "measureMs": 4.300000071525574,
-      "prepareMs": 10.600000023841858,
+      "analysisMs": 6.100000023841858,
+      "measureMs": 3.9000000953674316,
+      "prepareMs": 9.900000095367432,
       "layoutMs": 0.056999999880790714
     },
     {
@@ -1328,7 +1328,7 @@
       "lineCount": 81,
       "analysisMs": 0.5,
       "measureMs": 0.3999999761581421,
-      "prepareMs": 0.9000000953674316,
+      "prepareMs": 0.8999999761581421,
       "layoutMs": 0.003999999761581421
     },
     {
@@ -1357,8 +1357,8 @@
       "width": 300,
       "lineCount": 352,
       "analysisMs": 1.7999999523162842,
-      "measureMs": 2.3000000715255737,
-      "prepareMs": 4.199999928474426,
+      "measureMs": 2.100000023841858,
+      "prepareMs": 4,
       "layoutMs": 0.025
     },
     {
@@ -1373,8 +1373,8 @@
       "lineCount": 591,
       "analysisMs": 3.600000023841858,
       "measureMs": 3.299999952316284,
-      "prepareMs": 7.100000023841858,
-      "layoutMs": 0.05549999952316284
+      "prepareMs": 6.899999976158142,
+      "layoutMs": 0.055
     },
     {
       "id": "hi-eidgah",
@@ -1387,8 +1387,8 @@
       "width": 300,
       "lineCount": 653,
       "analysisMs": 2.799999952316284,
-      "measureMs": 4.299999952316284,
-      "prepareMs": 7.100000023841858,
+      "measureMs": 4.099999904632568,
+      "prepareMs": 6.800000071525574,
       "layoutMs": 0.04449999988079071
     },
     {
@@ -1402,9 +1402,9 @@
       "width": 300,
       "lineCount": 2860,
       "analysisMs": 3.299999952316284,
-      "measureMs": 6.599999904632568,
-      "prepareMs": 9.899999976158142,
-      "layoutMs": 0.2764999997615814
+      "measureMs": 6.5,
+      "prepareMs": 9.700000047683716,
+      "layoutMs": 0.2725
     },
     {
       "id": "ar-risalat-al-ghufran-part-1",
@@ -1416,10 +1416,10 @@
       "breakableSegments": 18759,
       "width": 300,
       "lineCount": 2643,
-      "analysisMs": 11.599999904632568,
-      "measureMs": 24.200000166893005,
-      "prepareMs": 36.5,
-      "layoutMs": 0.1725
+      "analysisMs": 11.5,
+      "measureMs": 22.200000047683716,
+      "prepareMs": 33.60000002384186,
+      "layoutMs": 0.16299999952316285
     }
   ]
 }

--- a/benchmarks/safari.json
+++ b/benchmarks/safari.json
@@ -3,22 +3,22 @@
   "runs": [
     {
       "status": "ready",
-      "requestId": "1789283703759-0-ac9estksl2f",
+      "requestId": "1789296019866-0-e8z9vcse4nw",
       "environment": {
         "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5.2 Safari/605.1.15",
         "start": {
           "dpr": 2,
           "visualViewportScale": 1,
-          "innerWidth": 1440,
-          "innerHeight": 2440,
-          "outerWidth": 1440,
-          "outerHeight": 2530,
-          "screenX": 2560,
+          "innerWidth": 2560,
+          "innerHeight": 1225,
+          "outerWidth": 2560,
+          "outerHeight": 1315,
+          "screenX": 0,
           "screenY": 30,
-          "screenWidth": 1440,
-          "screenHeight": 2560,
-          "screenAvailWidth": 1440,
-          "screenAvailHeight": 2530,
+          "screenWidth": 2560,
+          "screenHeight": 1440,
+          "screenAvailWidth": 2560,
+          "screenAvailHeight": 1315,
           "visibility": "visible",
           "focused": true,
           "language": "en",
@@ -27,16 +27,16 @@
         "end": {
           "dpr": 2,
           "visualViewportScale": 1,
-          "innerWidth": 1440,
-          "innerHeight": 2440,
-          "outerWidth": 1440,
-          "outerHeight": 2530,
-          "screenX": 2560,
+          "innerWidth": 2560,
+          "innerHeight": 1225,
+          "outerWidth": 2560,
+          "outerHeight": 1315,
+          "screenX": 0,
           "screenY": 30,
-          "screenWidth": 1440,
-          "screenHeight": 2560,
-          "screenAvailWidth": 1440,
-          "screenAvailHeight": 2530,
+          "screenWidth": 2560,
+          "screenHeight": 1440,
+          "screenAvailWidth": 2560,
+          "screenAvailHeight": 1315,
           "visibility": "visible",
           "focused": true,
           "language": "en",
@@ -58,7 +58,7 @@
           "analysisMs": 1,
           "measureMs": 2,
           "prepareMs": 3,
-          "layoutMs": 0.014999999999995453
+          "layoutMs": 0.015
         },
         {
           "id": "ja-rashomon",
@@ -70,10 +70,10 @@
           "breakableSegments": 6,
           "width": 300,
           "lineCount": 380,
-          "analysisMs": 2.0000000000009095,
-          "measureMs": 3,
-          "prepareMs": 5,
-          "layoutMs": 0.025000000000004546
+          "analysisMs": 2,
+          "measureMs": 3.0000000000009095,
+          "prepareMs": 5.0000000000009095,
+          "layoutMs": 0.025
         },
         {
           "id": "ko-unsu-joh-eun-nal",
@@ -86,8 +86,8 @@
           "width": 300,
           "lineCount": 428,
           "analysisMs": 2,
-          "measureMs": 4,
-          "prepareMs": 6,
+          "measureMs": 3.0000000000009095,
+          "prepareMs": 5,
           "layoutMs": 0.055
         },
         {
@@ -115,10 +115,10 @@
           "breakableSegments": 2,
           "width": 300,
           "lineCount": 626,
-          "analysisMs": 4,
-          "measureMs": 7.999999999998181,
+          "analysisMs": 3.9999999999990905,
+          "measureMs": 8,
           "prepareMs": 11,
-          "layoutMs": 0.04499999999999545
+          "layoutMs": 0.04
         },
         {
           "id": "zh-guxiang",
@@ -146,8 +146,8 @@
           "width": 300,
           "lineCount": 1024,
           "analysisMs": 6,
-          "measureMs": 16.99999999999909,
-          "prepareMs": 23,
+          "measureMs": 16,
+          "prepareMs": 22,
           "layoutMs": 0.06
         },
         {
@@ -160,8 +160,8 @@
           "breakableSegments": 424,
           "width": 300,
           "lineCount": 81,
-          "analysisMs": 0.999999999998181,
-          "measureMs": 2.000000000001819,
+          "analysisMs": 0.9999999999990905,
+          "measureMs": 2.0000000000009095,
           "prepareMs": 3,
           "layoutMs": 0.005
         },
@@ -191,9 +191,9 @@
           "width": 300,
           "lineCount": 352,
           "analysisMs": 2,
-          "measureMs": 32.00000000000182,
-          "prepareMs": 34.00000000000182,
-          "layoutMs": 0.035
+          "measureMs": 32,
+          "prepareMs": 34,
+          "layoutMs": 0.03
         },
         {
           "id": "km-prachum-reuang-preng-khmer-volume-7-stories-1-10",
@@ -206,8 +206,8 @@
           "width": 300,
           "lineCount": 591,
           "analysisMs": 5,
-          "measureMs": 11,
-          "prepareMs": 16,
+          "measureMs": 10,
+          "prepareMs": 15,
           "layoutMs": 0.065
         },
         {
@@ -221,7 +221,7 @@
           "width": 300,
           "lineCount": 653,
           "analysisMs": 3,
-          "measureMs": 22,
+          "measureMs": 22.00000000000182,
           "prepareMs": 25,
           "layoutMs": 0.055
         },
@@ -235,10 +235,10 @@
           "breakableSegments": 1540,
           "width": 300,
           "lineCount": 2860,
-          "analysisMs": 5.999999999998181,
-          "measureMs": 69,
-          "prepareMs": 74,
-          "layoutMs": 0.345
+          "analysisMs": 5,
+          "measureMs": 67,
+          "prepareMs": 72,
+          "layoutMs": 0.335
         },
         {
           "id": "ar-risalat-al-ghufran-part-1",
@@ -250,9 +250,9 @@
           "breakableSegments": 18759,
           "width": 300,
           "lineCount": 2644,
-          "analysisMs": 11,
-          "measureMs": 130.00000000000182,
-          "prepareMs": 141,
+          "analysisMs": 10.000000000001819,
+          "measureMs": 124,
+          "prepareMs": 135,
           "layoutMs": 0.205
         }
       ],
@@ -265,17 +265,17 @@
         {
           "label": "Our library: layout()",
           "desc": "Normalized hot-path throughput per 500-text batch",
-          "ms": 0.105
+          "ms": 0.1049999999999997
         },
         {
           "label": "DOM batch",
           "desc": "Single 400→300px batch resize: write all, then read all",
-          "ms": 51.500000000000114
+          "ms": 50
         },
         {
           "label": "DOM interleaved",
           "desc": "Single 400→300px batch resize: write + read per div",
-          "ms": 96.50000000000011
+          "ms": 96
         }
       ],
       "richResults": [
@@ -326,34 +326,34 @@
         {
           "label": "Our library: measureLineStats()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only",
-          "ms": 0.175
+          "ms": 0.15000000000001135
         },
         {
           "label": "Our library: layoutWithLines()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; materializes text lines",
-          "ms": 0.2750000000000228
+          "ms": 0.2
         },
         {
           "label": "Our library: walkLineRanges()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; line ranges only, no line text strings",
-          "ms": 0.32499999999999996
+          "ms": 0.34999999999998865
         },
         {
           "label": "Our library: layoutNextLine()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; streaming line-by-line layout",
-          "ms": 0.5499999999999887
+          "ms": 0.5
         }
       ],
       "richLongResults": [
         {
           "label": "Our library: measureLineStats()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; stats only",
-          "ms": 0.9
+          "ms": 0.85
         },
         {
           "label": "Our library: layoutWithLines()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines",
-          "ms": 2.912500000000011
+          "ms": 2.875
         },
         {
           "label": "Our library: walkLineRanges()",
@@ -363,28 +363,28 @@
         {
           "label": "Our library: layoutNextLine()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout",
-          "ms": 2.1125
+          "ms": 2.025000000000011
         }
       ]
     },
     {
       "status": "ready",
-      "requestId": "1789283717093-1-1xmuibrxkkg",
+      "requestId": "1789296032798-1-irpbpky7d2a",
       "environment": {
         "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5.2 Safari/605.1.15",
         "start": {
           "dpr": 2,
           "visualViewportScale": 1,
-          "innerWidth": 1440,
-          "innerHeight": 2440,
-          "outerWidth": 1440,
-          "outerHeight": 2530,
-          "screenX": 2560,
+          "innerWidth": 2560,
+          "innerHeight": 1225,
+          "outerWidth": 2560,
+          "outerHeight": 1315,
+          "screenX": 0,
           "screenY": 30,
-          "screenWidth": 1440,
-          "screenHeight": 2560,
-          "screenAvailWidth": 1440,
-          "screenAvailHeight": 2530,
+          "screenWidth": 2560,
+          "screenHeight": 1440,
+          "screenAvailWidth": 2560,
+          "screenAvailHeight": 1315,
           "visibility": "visible",
           "focused": true,
           "language": "en",
@@ -393,16 +393,16 @@
         "end": {
           "dpr": 2,
           "visualViewportScale": 1,
-          "innerWidth": 1440,
-          "innerHeight": 2440,
-          "outerWidth": 1440,
-          "outerHeight": 2530,
-          "screenX": 2560,
+          "innerWidth": 2560,
+          "innerHeight": 1225,
+          "outerWidth": 2560,
+          "outerHeight": 1315,
+          "screenX": 0,
           "screenY": 30,
-          "screenWidth": 1440,
-          "screenHeight": 2560,
-          "screenAvailWidth": 1440,
-          "screenAvailHeight": 2530,
+          "screenWidth": 2560,
+          "screenHeight": 1440,
+          "screenAvailWidth": 2560,
+          "screenAvailHeight": 1315,
           "visibility": "visible",
           "focused": true,
           "language": "en",
@@ -422,8 +422,8 @@
           "width": 300,
           "lineCount": 193,
           "analysisMs": 1,
-          "measureMs": 2.0000000000009095,
-          "prepareMs": 3.0000000000009095,
+          "measureMs": 3,
+          "prepareMs": 4,
           "layoutMs": 0.015
         },
         {
@@ -436,10 +436,10 @@
           "breakableSegments": 6,
           "width": 300,
           "lineCount": 380,
-          "analysisMs": 2,
-          "measureMs": 4,
-          "prepareMs": 6,
-          "layoutMs": 0.03
+          "analysisMs": 2.0000000000009095,
+          "measureMs": 3.999999999998181,
+          "prepareMs": 5.9999999999990905,
+          "layoutMs": 0.029999999999995454
         },
         {
           "id": "ko-unsu-joh-eun-nal",
@@ -451,10 +451,10 @@
           "breakableSegments": 3,
           "width": 300,
           "lineCount": 428,
-          "analysisMs": 2.0000000000009095,
-          "measureMs": 3.999999999998181,
+          "analysisMs": 2,
+          "measureMs": 4,
           "prepareMs": 5.9999999999990905,
-          "layoutMs": 0.06
+          "layoutMs": 0.055
         },
         {
           "id": "ko-sonagi",
@@ -466,10 +466,10 @@
           "breakableSegments": 3,
           "width": 300,
           "lineCount": 332,
-          "analysisMs": 1.0000000000009095,
-          "measureMs": 3.999999999998181,
-          "prepareMs": 5,
-          "layoutMs": 0.045
+          "analysisMs": 1,
+          "measureMs": 3,
+          "prepareMs": 4,
+          "layoutMs": 0.04
         },
         {
           "id": "zh-zhufu",
@@ -481,10 +481,10 @@
           "breakableSegments": 2,
           "width": 300,
           "lineCount": 626,
-          "analysisMs": 4,
-          "measureMs": 6.0000000000009095,
-          "prepareMs": 10,
-          "layoutMs": 0.04999999999999545
+          "analysisMs": 3.9999999999990905,
+          "measureMs": 7.0000000000009095,
+          "prepareMs": 10.00000000000091,
+          "layoutMs": 0.045
         },
         {
           "id": "zh-guxiang",
@@ -496,9 +496,9 @@
           "breakableSegments": 14,
           "width": 300,
           "lineCount": 375,
-          "analysisMs": 2.0000000000009095,
-          "measureMs": 4.9999999999990905,
-          "prepareMs": 7,
+          "analysisMs": 2,
+          "measureMs": 4.999999999998181,
+          "prepareMs": 6.9999999999990905,
           "layoutMs": 0.025000000000004546
         },
         {
@@ -511,10 +511,10 @@
           "breakableSegments": 8087,
           "width": 300,
           "lineCount": 1024,
-          "analysisMs": 6,
-          "measureMs": 18,
-          "prepareMs": 24,
-          "layoutMs": 0.065
+          "analysisMs": 5.999999999998181,
+          "measureMs": 17,
+          "prepareMs": 23,
+          "layoutMs": 0.06
         },
         {
           "id": "my-cunning-heron-teacher",
@@ -571,10 +571,10 @@
           "breakableSegments": 3540,
           "width": 300,
           "lineCount": 591,
-          "analysisMs": 5,
+          "analysisMs": 4,
           "measureMs": 10,
-          "prepareMs": 15,
-          "layoutMs": 0.07
+          "prepareMs": 14.999999999998181,
+          "layoutMs": 0.065
         },
         {
           "id": "hi-eidgah",
@@ -588,7 +588,7 @@
           "lineCount": 653,
           "analysisMs": 3,
           "measureMs": 23,
-          "prepareMs": 26,
+          "prepareMs": 25,
           "layoutMs": 0.055
         },
         {
@@ -601,10 +601,10 @@
           "breakableSegments": 1540,
           "width": 300,
           "lineCount": 2860,
-          "analysisMs": 4.000000000001819,
-          "measureMs": 71.99999999999636,
-          "prepareMs": 75.99999999999818,
-          "layoutMs": 0.35
+          "analysisMs": 5,
+          "measureMs": 66,
+          "prepareMs": 71,
+          "layoutMs": 0.34
         },
         {
           "id": "ar-risalat-al-ghufran-part-1",
@@ -616,39 +616,39 @@
           "breakableSegments": 18759,
           "width": 300,
           "lineCount": 2644,
-          "analysisMs": 12,
-          "measureMs": 130,
-          "prepareMs": 142,
-          "layoutMs": 0.215
+          "analysisMs": 10.999999999998181,
+          "measureMs": 125.00000000000182,
+          "prepareMs": 135.00000000000182,
+          "layoutMs": 0.205
         }
       ],
       "results": [
         {
           "label": "Our library: prepare()",
           "desc": "One cold 500-text measurement batch",
-          "ms": 11.000000000000028
+          "ms": 11.500000000000028
         },
         {
           "label": "Our library: layout()",
           "desc": "Normalized hot-path throughput per 500-text batch",
-          "ms": 0.105
+          "ms": 0.10000000000000028
         },
         {
           "label": "DOM batch",
           "desc": "Single 400→300px batch resize: write all, then read all",
-          "ms": 51
+          "ms": 49.5
         },
         {
           "label": "DOM interleaved",
           "desc": "Single 400→300px batch resize: write + read per div",
-          "ms": 98
+          "ms": 95.5
         }
       ],
       "richResults": [
         {
           "label": "Our library: measureLineStats()",
           "desc": "60-text shared-corpus batch across widths 180/220/260px; stats only",
-          "ms": 0.025
+          "ms": 0.024999999999988632
         },
         {
           "label": "Our library: layoutWithLines()",
@@ -658,7 +658,7 @@
         {
           "label": "Our library: walkLineRanges()",
           "desc": "60-text shared-corpus batch across widths 180/220/260px; line ranges only, no line text strings",
-          "ms": 0.02499999999999432
+          "ms": 0.0125
         },
         {
           "label": "Our library: layoutNextLine()",
@@ -680,7 +680,7 @@
         {
           "label": "Our library: materializeRichInlineLineRange()",
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; range walker plus per-line materialization",
-          "ms": 0.05
+          "ms": 0.037500000000000006
         },
         {
           "label": "Our library: layoutNextRichInlineLineRange() + materializeRichInlineLineRange()",
@@ -692,65 +692,65 @@
         {
           "label": "Our library: measureLineStats()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only",
-          "ms": 0.2
+          "ms": 0.15
         },
         {
           "label": "Our library: layoutWithLines()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; materializes text lines",
-          "ms": 0.3
+          "ms": 0.25
         },
         {
           "label": "Our library: walkLineRanges()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; line ranges only, no line text strings",
-          "ms": 0.375
+          "ms": 0.35
         },
         {
           "label": "Our library: layoutNextLine()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; streaming line-by-line layout",
-          "ms": 0.55
+          "ms": 0.5
         }
       ],
       "richLongResults": [
         {
           "label": "Our library: measureLineStats()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; stats only",
-          "ms": 0.9749999999999943
+          "ms": 0.9375
         },
         {
           "label": "Our library: layoutWithLines()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines",
-          "ms": 3.15
+          "ms": 2.9999999999999942
         },
         {
           "label": "Our library: walkLineRanges()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; line ranges only, no line text strings",
-          "ms": 1.775
+          "ms": 1.725
         },
         {
           "label": "Our library: layoutNextLine()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout",
-          "ms": 2.35
+          "ms": 2.2
         }
       ]
     },
     {
       "status": "ready",
-      "requestId": "1789283730685-2-3tuabk2fg9y",
+      "requestId": "1789296045710-2-bj48lqwe5hg",
       "environment": {
         "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5.2 Safari/605.1.15",
         "start": {
           "dpr": 2,
           "visualViewportScale": 1,
-          "innerWidth": 1440,
-          "innerHeight": 2440,
-          "outerWidth": 1440,
-          "outerHeight": 2530,
-          "screenX": 2560,
+          "innerWidth": 2560,
+          "innerHeight": 1225,
+          "outerWidth": 2560,
+          "outerHeight": 1315,
+          "screenX": 0,
           "screenY": 30,
-          "screenWidth": 1440,
-          "screenHeight": 2560,
-          "screenAvailWidth": 1440,
-          "screenAvailHeight": 2530,
+          "screenWidth": 2560,
+          "screenHeight": 1440,
+          "screenAvailWidth": 2560,
+          "screenAvailHeight": 1315,
           "visibility": "visible",
           "focused": true,
           "language": "en",
@@ -759,16 +759,16 @@
         "end": {
           "dpr": 2,
           "visualViewportScale": 1,
-          "innerWidth": 1440,
-          "innerHeight": 2440,
-          "outerWidth": 1440,
-          "outerHeight": 2530,
-          "screenX": 2560,
+          "innerWidth": 2560,
+          "innerHeight": 1225,
+          "outerWidth": 2560,
+          "outerHeight": 1315,
+          "screenX": 0,
           "screenY": 30,
-          "screenWidth": 1440,
-          "screenHeight": 2560,
-          "screenAvailWidth": 1440,
-          "screenAvailHeight": 2530,
+          "screenWidth": 2560,
+          "screenHeight": 1440,
+          "screenAvailWidth": 2560,
+          "screenAvailHeight": 1315,
           "visibility": "visible",
           "focused": true,
           "language": "en",
@@ -788,8 +788,8 @@
           "width": 300,
           "lineCount": 193,
           "analysisMs": 1,
-          "measureMs": 2,
-          "prepareMs": 3,
+          "measureMs": 3,
+          "prepareMs": 4,
           "layoutMs": 0.015
         },
         {
@@ -817,9 +817,9 @@
           "breakableSegments": 3,
           "width": 300,
           "lineCount": 428,
-          "analysisMs": 2,
-          "measureMs": 5.0000000000009095,
-          "prepareMs": 7.0000000000009095,
+          "analysisMs": 1.0000000000009095,
+          "measureMs": 4.999999999998181,
+          "prepareMs": 6,
           "layoutMs": 0.055
         },
         {
@@ -833,8 +833,8 @@
           "width": 300,
           "lineCount": 332,
           "analysisMs": 1,
-          "measureMs": 4,
-          "prepareMs": 5,
+          "measureMs": 3.0000000000009095,
+          "prepareMs": 4.0000000000009095,
           "layoutMs": 0.04
         },
         {
@@ -847,9 +847,9 @@
           "breakableSegments": 2,
           "width": 300,
           "lineCount": 626,
-          "analysisMs": 3,
-          "measureMs": 6.9999999999990905,
-          "prepareMs": 10,
+          "analysisMs": 4,
+          "measureMs": 7,
+          "prepareMs": 11,
           "layoutMs": 0.045
         },
         {
@@ -878,9 +878,9 @@
           "width": 300,
           "lineCount": 1024,
           "analysisMs": 6,
-          "measureMs": 16.999999999996362,
-          "prepareMs": 22.99999999999818,
-          "layoutMs": 0.065
+          "measureMs": 17,
+          "prepareMs": 23,
+          "layoutMs": 0.060000000000009095
         },
         {
           "id": "my-cunning-heron-teacher",
@@ -892,8 +892,8 @@
           "breakableSegments": 424,
           "width": 300,
           "lineCount": 81,
-          "analysisMs": 0,
-          "measureMs": 2.999999999998181,
+          "analysisMs": 0.999999999998181,
+          "measureMs": 2.000000000001819,
           "prepareMs": 3,
           "layoutMs": 0.005
         },
@@ -923,8 +923,8 @@
           "width": 300,
           "lineCount": 352,
           "analysisMs": 2,
-          "measureMs": 34,
-          "prepareMs": 36,
+          "measureMs": 32.00000000000182,
+          "prepareMs": 34.00000000000182,
           "layoutMs": 0.035
         },
         {
@@ -938,8 +938,8 @@
           "width": 300,
           "lineCount": 591,
           "analysisMs": 4,
-          "measureMs": 11,
-          "prepareMs": 16,
+          "measureMs": 10,
+          "prepareMs": 15,
           "layoutMs": 0.065
         },
         {
@@ -955,7 +955,7 @@
           "analysisMs": 3,
           "measureMs": 22,
           "prepareMs": 25,
-          "layoutMs": 0.06
+          "layoutMs": 0.055
         },
         {
           "id": "synthetic-long-breakable-runs",
@@ -968,9 +968,9 @@
           "width": 300,
           "lineCount": 2860,
           "analysisMs": 4,
-          "measureMs": 71.00000000000182,
-          "prepareMs": 76.00000000000182,
-          "layoutMs": 0.35
+          "measureMs": 69,
+          "prepareMs": 73,
+          "layoutMs": 0.345
         },
         {
           "id": "ar-risalat-al-ghufran-part-1",
@@ -982,10 +982,10 @@
           "breakableSegments": 18759,
           "width": 300,
           "lineCount": 2644,
-          "analysisMs": 11,
-          "measureMs": 132,
-          "prepareMs": 143,
-          "layoutMs": 0.2199999999999909
+          "analysisMs": 10.000000000001819,
+          "measureMs": 125.99999999999636,
+          "prepareMs": 136,
+          "layoutMs": 0.21
         }
       ],
       "results": [
@@ -1002,12 +1002,12 @@
         {
           "label": "DOM batch",
           "desc": "Single 400→300px batch resize: write all, then read all",
-          "ms": 53
+          "ms": 50.99999999999994
         },
         {
           "label": "DOM interleaved",
           "desc": "Single 400→300px batch resize: write + read per div",
-          "ms": 101.49999999999989
+          "ms": 95.99999999999977
         }
       ],
       "richResults": [
@@ -1019,7 +1019,7 @@
         {
           "label": "Our library: layoutWithLines()",
           "desc": "60-text shared-corpus batch across widths 180/220/260px; materializes text lines",
-          "ms": 0.037499999999994316
+          "ms": 0.025
         },
         {
           "label": "Our library: walkLineRanges()",
@@ -1051,51 +1051,51 @@
         {
           "label": "Our library: layoutNextRichInlineLineRange() + materializeRichInlineLineRange()",
           "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; streaming range walk plus per-line materialization",
-          "ms": 0.025000000000005684
+          "ms": 0.025
         }
       ],
       "richPreWrapResults": [
         {
           "label": "Our library: measureLineStats()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only",
-          "ms": 0.2
+          "ms": 0.15
         },
         {
           "label": "Our library: layoutWithLines()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; materializes text lines",
-          "ms": 0.325
+          "ms": 0.22500000000001139
         },
         {
           "label": "Our library: walkLineRanges()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; line ranges only, no line text strings",
-          "ms": 0.4
+          "ms": 0.3
         },
         {
           "label": "Our library: layoutNextLine()",
           "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; streaming line-by-line layout",
-          "ms": 0.55
+          "ms": 0.5
         }
       ],
       "richLongResults": [
         {
           "label": "Our library: measureLineStats()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; stats only",
-          "ms": 0.9750000000000056
+          "ms": 0.9249999999999943
         },
         {
           "label": "Our library: layoutWithLines()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines",
-          "ms": 3.225
+          "ms": 3.024999999999989
         },
         {
           "label": "Our library: walkLineRanges()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; line ranges only, no line text strings",
-          "ms": 1.8250000000000113
+          "ms": 1.725
         },
         {
           "label": "Our library: layoutNextLine()",
           "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout",
-          "ms": 2.3875
+          "ms": 2.2
         }
       ]
     }
@@ -1104,22 +1104,22 @@
     {
       "label": "Our library: prepare()",
       "desc": "One cold 500-text measurement batch",
-      "ms": 11.000000000000028
+      "ms": 11.500000000000028
     },
     {
       "label": "Our library: layout()",
       "desc": "Normalized hot-path throughput per 500-text batch",
-      "ms": 0.105
+      "ms": 0.1049999999999997
     },
     {
       "label": "DOM batch",
       "desc": "Single 400→300px batch resize: write all, then read all",
-      "ms": 51.500000000000114
+      "ms": 50
     },
     {
       "label": "DOM interleaved",
       "desc": "Single 400→300px batch resize: write + read per div",
-      "ms": 98
+      "ms": 95.99999999999977
     }
   ],
   "richResults": [
@@ -1131,12 +1131,12 @@
     {
       "label": "Our library: layoutWithLines()",
       "desc": "60-text shared-corpus batch across widths 180/220/260px; materializes text lines",
-      "ms": 0.025000000000005684
+      "ms": 0.025
     },
     {
       "label": "Our library: walkLineRanges()",
       "desc": "60-text shared-corpus batch across widths 180/220/260px; line ranges only, no line text strings",
-      "ms": 0.02499999999999432
+      "ms": 0.0125
     },
     {
       "label": "Our library: layoutNextLine()",
@@ -1158,7 +1158,7 @@
     {
       "label": "Our library: materializeRichInlineLineRange()",
       "desc": "36 rich-text inline flow shared-corpus texts across widths 180/220/260px; range walker plus per-line materialization",
-      "ms": 0.05
+      "ms": 0.037500000000000006
     },
     {
       "label": "Our library: layoutNextRichInlineLineRange() + materializeRichInlineLineRange()",
@@ -1170,44 +1170,44 @@
     {
       "label": "Our library: measureLineStats()",
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; stats only",
-      "ms": 0.2
+      "ms": 0.15
     },
     {
       "label": "Our library: layoutWithLines()",
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; materializes text lines",
-      "ms": 0.3
+      "ms": 0.22500000000001139
     },
     {
       "label": "Our library: walkLineRanges()",
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; line ranges only, no line text strings",
-      "ms": 0.375
+      "ms": 0.34999999999998865
     },
     {
       "label": "Our library: layoutNextLine()",
       "desc": "12 generated pre-wrap texts with 320 hard-break chunks across widths 220/260/320px; streaming line-by-line layout",
-      "ms": 0.55
+      "ms": 0.5
     }
   ],
   "richLongResults": [
     {
       "label": "Our library: measureLineStats()",
       "desc": "8 Arabic long-form texts across widths 240/300/360px; stats only",
-      "ms": 0.9749999999999943
+      "ms": 0.9249999999999943
     },
     {
       "label": "Our library: layoutWithLines()",
       "desc": "8 Arabic long-form texts across widths 240/300/360px; materializes text lines",
-      "ms": 3.15
+      "ms": 2.9999999999999942
     },
     {
       "label": "Our library: walkLineRanges()",
       "desc": "8 Arabic long-form texts across widths 240/300/360px; line ranges only, no line text strings",
-      "ms": 1.775
+      "ms": 1.725
     },
     {
       "label": "Our library: layoutNextLine()",
       "desc": "8 Arabic long-form texts across widths 240/300/360px; streaming line-by-line layout",
-      "ms": 2.35
+      "ms": 2.2
     }
   ],
   "corpusResults": [
@@ -1222,8 +1222,8 @@
       "width": 300,
       "lineCount": 193,
       "analysisMs": 1,
-      "measureMs": 2,
-      "prepareMs": 3,
+      "measureMs": 3,
+      "prepareMs": 4,
       "layoutMs": 0.015
     },
     {
@@ -1237,9 +1237,9 @@
       "width": 300,
       "lineCount": 380,
       "analysisMs": 2,
-      "measureMs": 4,
-      "prepareMs": 6,
-      "layoutMs": 0.03
+      "measureMs": 3.999999999998181,
+      "prepareMs": 5.9999999999990905,
+      "layoutMs": 0.029999999999995454
     },
     {
       "id": "ko-unsu-joh-eun-nal",
@@ -1253,7 +1253,7 @@
       "lineCount": 428,
       "analysisMs": 2,
       "measureMs": 4,
-      "prepareMs": 6,
+      "prepareMs": 5.9999999999990905,
       "layoutMs": 0.055
     },
     {
@@ -1267,8 +1267,8 @@
       "width": 300,
       "lineCount": 332,
       "analysisMs": 1,
-      "measureMs": 4,
-      "prepareMs": 5,
+      "measureMs": 3.0000000000009095,
+      "prepareMs": 4.0000000000009095,
       "layoutMs": 0.04
     },
     {
@@ -1281,9 +1281,9 @@
       "breakableSegments": 2,
       "width": 300,
       "lineCount": 626,
-      "analysisMs": 4,
-      "measureMs": 6.9999999999990905,
-      "prepareMs": 10,
+      "analysisMs": 3.9999999999990905,
+      "measureMs": 7.0000000000009095,
+      "prepareMs": 11,
       "layoutMs": 0.045
     },
     {
@@ -1312,9 +1312,9 @@
       "width": 300,
       "lineCount": 1024,
       "analysisMs": 6,
-      "measureMs": 16.99999999999909,
+      "measureMs": 17,
       "prepareMs": 23,
-      "layoutMs": 0.065
+      "layoutMs": 0.06
     },
     {
       "id": "my-cunning-heron-teacher",
@@ -1326,8 +1326,8 @@
       "breakableSegments": 424,
       "width": 300,
       "lineCount": 81,
-      "analysisMs": 0,
-      "measureMs": 2.999999999998181,
+      "analysisMs": 0.999999999998181,
+      "measureMs": 2.000000000001819,
       "prepareMs": 3,
       "layoutMs": 0.005
     },
@@ -1357,8 +1357,8 @@
       "width": 300,
       "lineCount": 352,
       "analysisMs": 2,
-      "measureMs": 33,
-      "prepareMs": 35,
+      "measureMs": 32.00000000000182,
+      "prepareMs": 34.00000000000182,
       "layoutMs": 0.035
     },
     {
@@ -1371,9 +1371,9 @@
       "breakableSegments": 3540,
       "width": 300,
       "lineCount": 591,
-      "analysisMs": 5,
-      "measureMs": 11,
-      "prepareMs": 16,
+      "analysisMs": 4,
+      "measureMs": 10,
+      "prepareMs": 15,
       "layoutMs": 0.065
     },
     {
@@ -1387,7 +1387,7 @@
       "width": 300,
       "lineCount": 653,
       "analysisMs": 3,
-      "measureMs": 22,
+      "measureMs": 22.00000000000182,
       "prepareMs": 25,
       "layoutMs": 0.055
     },
@@ -1401,10 +1401,10 @@
       "breakableSegments": 1540,
       "width": 300,
       "lineCount": 2860,
-      "analysisMs": 4.000000000001819,
-      "measureMs": 71.00000000000182,
-      "prepareMs": 75.99999999999818,
-      "layoutMs": 0.35
+      "analysisMs": 5,
+      "measureMs": 67,
+      "prepareMs": 72,
+      "layoutMs": 0.34
     },
     {
       "id": "ar-risalat-al-ghufran-part-1",
@@ -1416,10 +1416,10 @@
       "breakableSegments": 18759,
       "width": 300,
       "lineCount": 2644,
-      "analysisMs": 11,
-      "measureMs": 130.00000000000182,
-      "prepareMs": 142,
-      "layoutMs": 0.215
+      "analysisMs": 10.000000000001819,
+      "measureMs": 125.00000000000182,
+      "prepareMs": 135.00000000000182,
+      "layoutMs": 0.205
     }
   ]
 }

--- a/corpora/chrome-step10.json
+++ b/corpora/chrome-step10.json
@@ -1,20 +1,20 @@
 [
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -85,21 +85,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -259,21 +259,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -377,21 +377,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -495,21 +495,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -580,21 +580,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -665,21 +665,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -750,21 +750,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -835,21 +835,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -937,21 +937,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1031,21 +1031,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1116,21 +1116,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1201,21 +1201,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1286,21 +1286,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1371,21 +1371,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1456,21 +1456,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1541,21 +1541,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1626,21 +1626,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },

--- a/corpora/firefox-step10.json
+++ b/corpora/firefox-step10.json
@@ -1,20 +1,20 @@
 [
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -166,21 +166,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -740,21 +740,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -825,21 +825,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -910,21 +910,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1028,21 +1028,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1113,21 +1113,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1198,21 +1198,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1283,21 +1283,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1457,21 +1457,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1615,21 +1615,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1805,21 +1805,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1931,21 +1931,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -2041,21 +2041,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -2126,21 +2126,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -2211,21 +2211,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -2353,21 +2353,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -2438,21 +2438,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },

--- a/corpora/safari-step10.json
+++ b/corpora/safari-step10.json
@@ -1,20 +1,20 @@
 [
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -37,7 +37,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "mul",
             "direction": "ltr"
           },
@@ -55,7 +55,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "mul",
             "direction": "ltr"
           },
@@ -69,7 +69,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -85,21 +85,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -122,7 +122,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "en",
             "direction": "ltr"
           },
@@ -140,7 +140,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "en",
             "direction": "ltr"
           },
@@ -154,7 +154,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -195,21 +195,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -232,7 +232,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "ja",
             "direction": "ltr"
           },
@@ -250,7 +250,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "ja",
             "direction": "ltr"
           },
@@ -264,7 +264,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -280,21 +280,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -317,7 +317,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "ja",
             "direction": "ltr"
           },
@@ -335,7 +335,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "ja",
             "direction": "ltr"
           },
@@ -349,7 +349,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -365,21 +365,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -402,7 +402,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "ko",
             "direction": "ltr"
           },
@@ -420,7 +420,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "ko",
             "direction": "ltr"
           },
@@ -434,7 +434,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -450,21 +450,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -487,7 +487,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "ko",
             "direction": "ltr"
           },
@@ -505,7 +505,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "ko",
             "direction": "ltr"
           },
@@ -519,7 +519,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -535,21 +535,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -572,7 +572,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "zh",
             "direction": "ltr"
           },
@@ -590,7 +590,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "zh",
             "direction": "ltr"
           },
@@ -604,7 +604,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -620,21 +620,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -657,7 +657,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "zh",
             "direction": "ltr"
           },
@@ -675,7 +675,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "zh",
             "direction": "ltr"
           },
@@ -689,7 +689,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -705,21 +705,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -742,7 +742,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "th",
             "direction": "ltr"
           },
@@ -760,7 +760,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "th",
             "direction": "ltr"
           },
@@ -774,7 +774,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -790,21 +790,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -827,7 +827,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "th",
             "direction": "ltr"
           },
@@ -845,7 +845,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "th",
             "direction": "ltr"
           },
@@ -859,7 +859,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -875,21 +875,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -912,7 +912,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "my",
             "direction": "ltr"
           },
@@ -930,7 +930,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "my",
             "direction": "ltr"
           },
@@ -944,7 +944,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -985,21 +985,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1022,7 +1022,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "my",
             "direction": "ltr"
           },
@@ -1040,7 +1040,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "my",
             "direction": "ltr"
           },
@@ -1054,7 +1054,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -1087,21 +1087,21 @@
     ]
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1124,7 +1124,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "km",
             "direction": "ltr"
           },
@@ -1142,7 +1142,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "km",
             "direction": "ltr"
           },
@@ -1156,7 +1156,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -1172,21 +1172,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1209,7 +1209,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "ar",
             "direction": "rtl"
           },
@@ -1227,7 +1227,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "ar",
             "direction": "rtl"
           },
@@ -1241,7 +1241,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -1257,21 +1257,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1294,7 +1294,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "ar",
             "direction": "rtl"
           },
@@ -1312,7 +1312,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "ar",
             "direction": "rtl"
           },
@@ -1326,7 +1326,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -1342,21 +1342,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1379,7 +1379,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "hi",
             "direction": "ltr"
           },
@@ -1397,7 +1397,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "hi",
             "direction": "ltr"
           },
@@ -1411,7 +1411,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -1427,21 +1427,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1464,7 +1464,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "he",
             "direction": "rtl"
           },
@@ -1482,7 +1482,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "he",
             "direction": "rtl"
           },
@@ -1496,7 +1496,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],
@@ -1512,21 +1512,21 @@
     "mismatches": []
   },
   {
-    "generatedAt": "2026-09-13T06:12:54.772Z",
-    "suiteHash": "d8563bc0d932f356ca3ab7ea9b60a0f5d71fedfc52a8b3801a46bb5d902e1e07",
+    "generatedAt": "2026-09-13T10:44:29.917Z",
+    "suiteHash": "929092355b851441d24119c655ce3a7515e9017cacce55bd6e4d125cdf0cb9b5",
     "source": {
-      "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+      "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
       "files": {
-        "analysis.ts": "088e48fe402bb795dea3e16b138b5bd8858a1c73686668fb705beafaa69df36f",
+        "analysis.ts": "45c47ace789c8946f1c238a341b397664e610dd1bcad893daeaca10e363894c5",
         "bidi.ts": "7ce31d57033cf173559ae393efec23e4a93c8bae8c798ef46c68599079faf454",
         "entry-geometry.ts": "43ffacd71c3562283135590a06947eef4b2617cb3b6ba680c909dd5e2d2ba9a7",
         "generated/bidi-data.ts": "c4480cc4b1d4269f658779574d3b9c25121537f672e4e60be6a919a86fa230f8",
         "generated/line-break-data.ts": "3a42caa6039e2d59df4830d3d713d8e5692aae79e40d34c0b7f7f49e294fdd8a",
-        "layout.ts": "b342d28a5ab7bf26f098c0d7887e415f2e3628f14a72dac6c61ca0ef0bf08a36",
-        "line-break.ts": "6c39482d9894781cf488f4b5ca579873c6fc65c1f6b49ec452b4cf6436d2d398",
-        "line-text.ts": "5e21684d995df8c30324c03a14b8a0bc3a579ce169a0e10b6d579b6aeee577dc",
-        "measurement.ts": "826b1e0f940690d4c0cc4a7268a56c5ff673a2b61ae6d35ec3ba115d1c1d0990",
-        "rich-inline.ts": "2a3cf105def4d45fc28c39cee5b960536d8e7e5d62a99bea79de39dda7d636e7",
+        "layout.ts": "542b5e97622f26f482b6927462dad9692259ccf65eabc22f741e6adddc3cf5f0",
+        "line-break.ts": "d58f099ceec536438da532b071c7e3287af52d380469d7327ddf61dcadb9fb45",
+        "line-text.ts": "31abd7a69c9e4a4dbba57d2791038349e803e65813a819e4e3128e0544d25ae1",
+        "measurement.ts": "5e2ca67e40e654cce390c35022f2811238b0322980b05a7cc08e6496d2274d13",
+        "rich-inline.ts": "dd2a18d28995c01c46aa9ddb3b27564a8ed05fa20dc534c368ba27ff369a3667",
         "text-modules.d.ts": "1547f88f0eb75293bc20054194a2bba29a4bc911c2a4fa99cef98141b6f99927"
       }
     },
@@ -1549,7 +1549,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "ur",
             "direction": "rtl"
           },
@@ -1567,7 +1567,7 @@
             "screenAvailWidth": 2560,
             "screenAvailHeight": 1315,
             "visibility": "visible",
-            "focused": false,
+            "focused": true,
             "language": "ur",
             "direction": "rtl"
           },
@@ -1581,7 +1581,7 @@
         "dpr": 2,
         "locale": "zh-CN",
         "visibility": "visible",
-        "focused": false,
+        "focused": true,
         "fonts": []
       }
     ],

--- a/pages/probe.ts
+++ b/pages/probe.ts
@@ -479,6 +479,21 @@ function getFirstBreakMismatch(
   return null
 }
 
+// What a whole segment charges toward the line's fit width when the line ends
+// after it. Spaces and zero-width breaks hang, a soft hyphen charges its hyphen,
+// and other content charges its width and the letter-spacing gap after it,
+// except zero-width text. Tabs and hard breaks prepare with zero width.
+function getLineEndFitAdvance(prepared: PreparedTextWithSegments, segmentIndex: number): number {
+  const kind = prepared.kinds[segmentIndex]!
+  const width = prepared.widths[segmentIndex]!
+  if (kind === 'soft-hyphen') return prepared.discretionaryHyphenWidth
+  if (kind === 'space' || kind === 'preserved-space' || kind === 'zero-width-break') return 0
+  if (width === 0 && kind !== 'control') return 0
+  return prepared.letterSpacing !== 0 && prepared.spacingGraphemeCounts[segmentIndex]! > 0
+    ? width + prepared.letterSpacing
+    : width
+}
+
 function getBreakTrace(
   prepared: PreparedTextWithSegments,
   measuredFont: string,
@@ -530,7 +545,7 @@ function getBreakTrace(
     const unitWidth = measurePreparedSlice(prepared, unit.start, unit.end, measuredFont)
     const lineSliceWidth = measurePreparedSlice(prepared, lineStart, unit.end, measuredFont)
     const lineFitWidth = wholeSegment
-      ? lineSliceWidth - prepared.widths[segmentIndex]! + prepared.lineEndFitAdvances[segmentIndex]!
+      ? lineSliceWidth - prepared.widths[segmentIndex]! + getLineEndFitAdvance(prepared, segmentIndex)
       : lineSliceWidth
     const graphemeOrdinal = (graphemeOrdinalBySegment.get(segmentIndex) ?? 0) + 1
     graphemeOrdinalBySegment.set(segmentIndex, graphemeOrdinal)

--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -245,7 +245,7 @@ const letterOrNumberAtRe = /[\p{L}\p{N}]/uy
 function endsWithKeepAllLetter(text: string, profile: AnalysisProfile): boolean {
   const last = getLastCodePoint(text)
   if (last === null || !letterOrNumberRe.test(last)) return false
-  return profile.keepAllPairModel !== 'icu4x-classes' || !cjkNonstarters.has(last)
+  return profile.keepAllPairModel !== 'icu4x-classes' || getCJKLineStartClass(last) !== LineBreakClass.NS
 }
 
 // Ideographs, kana and Hangul syllables, which every keep-all pair model keeps.
@@ -500,29 +500,18 @@ function getKeepAllRunEnd(text: string, boundary: number, previousText: string, 
   return endsKeepAllRunAtPair(text, boundary, profile) ? 'split' : null
 }
 
-// UAX #14 NS code points in the CJK ranges above.
-const cjkNonstarters = new Set([
-  '\u3005', '\u301C', '\u303B', '\u303C', '\u309B', '\u309C', '\u309D', '\u309E',
-  '\u30A0', '\u30FB', '\u30FD', '\u30FE', '\uFF1A', '\uFF1B', '\uFF65', '\uFF9E',
-  '\uFF9F',
-])
-
-// Code points in the CJK ranges above that cannot start a line after other
-// text, by UAX #14 class (LineBreak.txt, Unicode 17). These ranges hold no CP,
-// IS, SY or IN code points. U+3000 is BA but a space that engines hang or trim
-// at a line end, so it is not listed.
-const cjkLineStartProhibited = new Set([
-  // CL (LB13)
-  '\u3001', '\u3002', '\u3009', '\u300B', '\u300D', '\u300F', '\u3011', '\u3015',
-  '\u3017', '\u3019', '\u301B', '\u301E', '\u301F', '\uFF09', '\uFF0C', '\uFF0E',
-  '\uFF3D', '\uFF5D', '\uFF60', '\uFF61', '\uFF63', '\uFF64',
-  // EX (LB13)
-  '\uFF01', '\uFF1F',
-  // NS (LB21)
-  ...cjkNonstarters,
-  // CM that does not extend a grapheme (LB9)
-  '\u3035',
-])
+// In Unicode 17, Pretext's CJK ranges above hold no CP, IS, SY or IN code
+// points, and U+3000 is their only BA: a space that engines hang or trim at a
+// line end, which needs its own model. So by UAX #14 class, the code points in
+// them that cannot start a line after other text are CL and EX (LB13), NS (LB21)
+// and the CM U+3035, which does not extend a grapheme (LB9). Each of those CL, EX
+// and NS code points is one code unit in U+3000-U+30FF or U+FF00-U+FFEF. Returns
+// the class of a one-code-unit text in those blocks, or -1.
+function getCJKLineStartClass(text: string): number {
+  if (text.length !== 1) return -1
+  const code = text.charCodeAt(0)
+  return (code >= 0x3000 && code <= 0x30FF) || (code >= 0xFF00 && code <= 0xFFEF) ? getLineBreakClass(code) : -1
+}
 
 // Small kana and U+30FC are UAX #14 CJ, which the profile resolves: ID may start
 // a line and NS may not.
@@ -532,7 +521,9 @@ function keepsConditionalJapaneseStarter(text: string, profile: AnalysisProfile)
 
 // Whether a grapheme or a code point cannot start a line after CJK text.
 function prohibitsCJKLineStart(text: string, profile: AnalysisProfile): boolean {
-  return cjkLineStartProhibited.has(text) || keepsConditionalJapaneseStarter(text, profile)
+  const lineBreakClass = getCJKLineStartClass(text)
+  return lineBreakClass === LineBreakClass.CL || lineBreakClass === LineBreakClass.EX || lineBreakClass === LineBreakClass.NS ||
+    text === '\u3035' || keepsConditionalJapaneseStarter(text, profile)
 }
 
 export const kinsokuEnd = new Set([
@@ -808,9 +799,10 @@ function isBasicCombiningMark(code: number): boolean {
   )
 }
 
-// UAX #14 BK, CR, LF and NL. LB7 forbids every other break before a ZWSP.
+// UAX #14 BK, CR, LF and NL, which the class table reads as BK. LB7 forbids every
+// other break before a ZWSP.
 function isMandatoryBreakCode(code: number): boolean {
-  return (code >= 0x0A && code <= 0x0D) || code === 0x85 || code === 0x2028 || code === 0x2029
+  return getLineBreakClass(code) === LineBreakClass.BK
 }
 
 // WebKit reports ZWSP|mark (LB8) only from an ICU lookup that starts before the
@@ -1223,16 +1215,13 @@ function breaksAfterExclamation(
 const hyphenWithMarksRe = /^.\p{M}+$/u
 const letterAtRe = /\p{L}/uy
 
-// A hyphen alone or followed only by combining marks. The astral HH dashes are
-// two code units.
+// A hyphen (UAX #14 HY or HH) alone or followed only by combining marks. The
+// astral HH dashes are two code units.
 function isHyphenPiece(text: string): boolean {
   const code = text.codePointAt(0)!
-  switch (code) {
-    case 0x2D: case 0x058A: case 0x05BE: case 0x1400: case 0x2010: case 0x2012:
-    case 0x2013: case 0x2E17: case 0x2E40: case 0x2E5D: case 0x10D6E: case 0x10EAD:
-      return text.length === (code > 0xFFFF ? 2 : 1) || hyphenWithMarksRe.test(text)
-  }
-  return false
+  const lineBreakClass = getLineBreakClass(code)
+  return (lineBreakClass === LineBreakClass.HY || lineBreakClass === LineBreakClass.HH) &&
+    (text.length === (code > 0xFFFF ? 2 : 1) || hyphenWithMarksRe.test(text))
 }
 
 // UAX #14 LB20a keeps a hyphen (HY or HH) after a space, ZWSP, hard break or

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -809,11 +809,10 @@ describe('boundary-policy regressions', () => {
   test('the WebKit profile keeps NEL with the content before it, breaks after it and gives it no letter spacing', async () => {
     const { getEngineProfile } = await import('./measurement.ts')
     const profile = getEngineProfile()
-    const previous = [profile.breakOnlyAfterNextLine, profile.letterSpaceNextLine, profile.keepAllPairModel] as const
+    const previous = [profile.breakOnlyAfterNextLine, profile.keepAllPairModel] as const
     // Blink and Gecko keep NEL as ordinary text.
     expect(prepareWithSegments('zz ab\u0085cd', FONT).kinds).not.toContain('control')
     profile.breakOnlyAfterNextLine = true
-    profile.letterSpaceNextLine = false
     profile.keepAllPairModel = 'webkit-spaces'
     try {
       const lines = (text: string, width: number, options?: { whiteSpace?: 'pre-wrap', letterSpacing?: number }) => {
@@ -877,7 +876,7 @@ describe('boundary-policy regressions', () => {
       // A preserved space does not hang after a NEL that already overflows.
       expect(lines('a\u0085 b', nel - 0.5, { whiteSpace: 'pre-wrap', letterSpacing: 1 }).map(line => line.text)).toEqual(['a', '\u0085', ' ', 'b'])
     } finally {
-      [profile.breakOnlyAfterNextLine, profile.letterSpaceNextLine, profile.keepAllPairModel] = previous
+      [profile.breakOnlyAfterNextLine, profile.keepAllPairModel] = previous
     }
   })
 

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -800,9 +800,9 @@ export function layout(prepared: PreparedText, maxWidth: number, lineHeight: num
   return { lineCount, height: lineCount * lineHeight }
 }
 
-// Every reported line is built here, so widths are clamped at zero here. A
-// line's advance can be negative: the rest of a word after an emergency break
-// can hold only invisible characters and the word's kerning with a following
+// Reported widths are clamped at zero wherever a line is built. A line's
+// advance can be negative: the rest of a word after an emergency break can
+// hold only invisible characters and the word's kerning with a following
 // space, and letter spacing can be strongly negative. Line breaking keeps the
 // signed advance.
 function createLayoutLine(
@@ -905,11 +905,29 @@ export function measureLineStats(
 // the prepared text when container width is not the thing forcing wraps?".
 // Explicit hard breaks still count, so this returns the widest forced line.
 export function measureNaturalWidth(prepared: PreparedTextWithSegments): number {
-  let maxWidth = 0
-  walkPreparedLinesRaw(getInternalPrepared(prepared), Number.POSITIVE_INFINITY, width => {
-    if (width > maxWidth) maxWidth = width
-  })
-  return maxWidth
+  return measureLineStats(prepared, Number.POSITIVE_INFINITY).maxLineWidth
+}
+
+// Steps one streamed line from `start` into the result's cursors: the
+// normalized line start and the line end. Returns the reported width, or null
+// after the last line.
+function stepNextLine(
+  prepared: PreparedTextWithSegments,
+  start: LayoutCursor,
+  maxWidth: number,
+  lineStart: LayoutCursor,
+  lineEnd: LayoutCursor,
+): number | null {
+  const internal = getInternalPrepared(prepared)
+  lineEnd.segmentIndex = start.segmentIndex
+  lineEnd.graphemeIndex = start.graphemeIndex
+  const chunkIndex = normalizePreparedLineStart(internal, lineEnd)
+  if (chunkIndex < 0) return null
+
+  lineStart.segmentIndex = lineEnd.segmentIndex
+  lineStart.graphemeIndex = lineEnd.graphemeIndex
+  const width = stepPreparedLineGeometryFromChunk(internal, lineEnd, chunkIndex, maxWidth)
+  return width === null ? null : Math.max(0, width)
 }
 
 export function layoutNextLine(
@@ -917,28 +935,20 @@ export function layoutNextLine(
   start: LayoutCursor,
   maxWidth: number,
 ): LayoutLine | null {
-  const internal = getInternalPrepared(prepared)
-  const end = {
-    segmentIndex: start.segmentIndex,
-    graphemeIndex: start.graphemeIndex,
-  }
-  const chunkIndex = normalizePreparedLineStart(internal, end)
-  if (chunkIndex < 0) return null
-
-  const lineStartSegmentIndex = end.segmentIndex
-  const lineStartGraphemeIndex = end.graphemeIndex
-  const width = stepPreparedLineGeometryFromChunk(internal, end, chunkIndex, maxWidth)
+  const lineStart = { segmentIndex: 0, graphemeIndex: 0 }
+  const end = { segmentIndex: 0, graphemeIndex: 0 }
+  const width = stepNextLine(prepared, start, maxWidth, lineStart, end)
   if (width === null) return null
 
-  return createLayoutLine(
+  const text = buildLineTextFromRange(
     prepared,
     getLineTextCache(prepared),
-    width,
-    lineStartSegmentIndex,
-    lineStartGraphemeIndex,
+    lineStart.segmentIndex,
+    lineStart.graphemeIndex,
     end.segmentIndex,
     end.graphemeIndex,
   )
+  return { text, width, start: lineStart, end }
 }
 
 export function layoutNextLineRange(
@@ -946,26 +956,10 @@ export function layoutNextLineRange(
   start: LayoutCursor,
   maxWidth: number,
 ): LayoutLineRange | null {
-  const internal = getInternalPrepared(prepared)
-  const end = {
-    segmentIndex: start.segmentIndex,
-    graphemeIndex: start.graphemeIndex,
-  }
-  const chunkIndex = normalizePreparedLineStart(internal, end)
-  if (chunkIndex < 0) return null
-
-  const lineStartSegmentIndex = end.segmentIndex
-  const lineStartGraphemeIndex = end.graphemeIndex
-  const width = stepPreparedLineGeometryFromChunk(internal, end, chunkIndex, maxWidth)
-  if (width === null) return null
-
-  return createLayoutLineRange(
-    width,
-    lineStartSegmentIndex,
-    lineStartGraphemeIndex,
-    end.segmentIndex,
-    end.graphemeIndex,
-  )
+  const lineStart = { segmentIndex: 0, graphemeIndex: 0 }
+  const end = { segmentIndex: 0, graphemeIndex: 0 }
+  const width = stepNextLine(prepared, start, maxWidth, lineStart, end)
+  return width === null ? null : { width, start: lineStart, end }
 }
 
 // Rich layout API for callers that want the actual line contents and widths.

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -59,8 +59,6 @@ declare const preparedTextBrand: unique symbol
 
 type PreparedCore = {
   widths: number[] // Segment widths, e.g. [42.5, 4.4, 37.2]
-  lineEndFitAdvances: number[] // Width contribution when a line ends after this segment
-  lineEndPaintAdvances: number[] // Painted contribution before terminal line-end letter-spacing
   kinds: SegmentBreakKind[] // Break behavior per segment, e.g. ['text', 'space', 'text']
   simpleLineWalkFastPath: boolean // Normal text can use the simpler old line walker across all layout APIs
   segLevels: Int8Array | null // Rich-path bidi metadata for custom rendering; layout() never reads it
@@ -145,8 +143,6 @@ function createEmptyPrepared(includeSegments: boolean): InternalPreparedText | P
   if (includeSegments) {
     return {
       widths: [],
-      lineEndFitAdvances: [],
-      lineEndPaintAdvances: [],
       kinds: [],
       simpleLineWalkFastPath: true,
       segLevels: null,
@@ -164,8 +160,6 @@ function createEmptyPrepared(includeSegments: boolean): InternalPreparedText | P
   }
   return {
     widths: [],
-    lineEndFitAdvances: [],
-    lineEndPaintAdvances: [],
     kinds: [],
     simpleLineWalkFastPath: true,
     segLevels: null,
@@ -423,8 +417,6 @@ function measureAnalysis(
   }
 
   const widths: number[] = []
-  const lineEndFitAdvances: number[] = []
-  const lineEndPaintAdvances: number[] = []
   const kinds: SegmentBreakKind[] = []
   let simpleLineWalkFastPath = !hasLetterSpacing
   const segStarts = includeSegments ? [] as number[] : null
@@ -504,8 +496,6 @@ function measureAnalysis(
   function pushMeasuredSegment(
     text: string,
     width: number,
-    lineEndFitAdvance: number,
-    lineEndPaintAdvance: number,
     kind: SegmentBreakKind,
     start: number,
     breakableFitAdvance: number[] | null,
@@ -517,8 +507,6 @@ function measureAnalysis(
       simpleLineWalkFastPath = false
     }
     widths.push(width)
-    lineEndFitAdvances.push(lineEndFitAdvance)
-    lineEndPaintAdvances.push(lineEndPaintAdvance)
     kinds.push(kind)
     segStarts?.push(start)
     breakableFitAdvances.push(breakableFitAdvance)
@@ -560,18 +548,6 @@ function measureAnalysis(
       spacingGraphemeCount,
       letterSpacing,
     )
-    const baseLineEndFitAdvance =
-      kind === 'space' || kind === 'preserved-space' || kind === 'zero-width-break'
-        ? 0
-        : width
-    const lineEndFitAdvance =
-      baseLineEndFitAdvance === 0
-        ? 0
-        : baseLineEndFitAdvance + (spacingGraphemeCount > 0 ? letterSpacing : 0)
-    const lineEndPaintAdvance =
-      kind === 'space' || kind === 'zero-width-break'
-        ? 0
-        : width
 
     if (allowOverflowBreaks && text.length > 1) {
       let fitMode: BreakableFitMode = 'sum-graphemes'
@@ -603,8 +579,6 @@ function measureAnalysis(
       pushMeasuredSegment(
         text,
         width,
-        lineEndFitAdvance,
-        lineEndPaintAdvance,
         kind,
         start,
         fitAdvances,
@@ -619,8 +593,6 @@ function measureAnalysis(
     pushMeasuredSegment(
       text,
       width,
-      lineEndFitAdvance,
-      lineEndPaintAdvance,
       kind,
       start,
       null,
@@ -639,8 +611,6 @@ function measureAnalysis(
       pushMeasuredSegment(
         segText,
         0,
-        discretionaryHyphenWidth,
-        discretionaryHyphenWidth,
         segKind,
         segStart,
         null,
@@ -656,7 +626,7 @@ function measureAnalysis(
 
     if (segKind === 'hard-break') {
       const endSegmentIndex = widths.length
-      pushMeasuredSegment(segText, 0, 0, 0, segKind, segStart, null, null, 0)
+      pushMeasuredSegment(segText, 0, segKind, segStart, null, null, 0)
       chunks.push({
         startSegmentIndex: chunkStartSegmentIndex,
         endSegmentIndex,
@@ -669,8 +639,6 @@ function measureAnalysis(
     if (segKind === 'tab') {
       pushMeasuredSegment(
         segText,
-        0,
-        0,
         0,
         segKind,
         segStart,
@@ -693,8 +661,7 @@ function measureAnalysis(
         ((previousKind === 'text' || previousKind === 'glue') && needsComplexTextPath(analysis.texts[mi - 1]!)) ||
         (leadingCombiningMarkRe.test(nextText) && needsComplexTextPath(nextText))
       )
-      const spacing = takesLetterSpacing ? letterSpacing : 0
-      pushMeasuredSegment(segText, width, width + spacing, width, segKind, segStart, null, null, takesLetterSpacing ? 1 : 0)
+      pushMeasuredSegment(segText, width, segKind, segStart, null, null, takesLetterSpacing ? 1 : 0)
       continue
     }
 
@@ -741,8 +708,6 @@ function measureAnalysis(
   if (segments !== null) {
     return {
       widths,
-      lineEndFitAdvances,
-      lineEndPaintAdvances,
       kinds,
       simpleLineWalkFastPath,
       segLevels,
@@ -760,8 +725,6 @@ function measureAnalysis(
   }
   return {
     widths,
-    lineEndFitAdvances,
-    lineEndPaintAdvances,
     kinds,
     simpleLineWalkFastPath,
     segLevels,

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -50,7 +50,6 @@ import {
 } from './line-break.js'
 import {
   buildLineTextFromRange,
-  clearLineTextCaches,
   getLineTextCache,
 } from './line-text.js'
 
@@ -464,19 +463,12 @@ function measureAnalysis(
     const nextKind = analysis.kinds[next]!
     if (nextKind !== 'text' && nextKind !== 'glue') return false
     const after = analysis.texts[next]!
-    const beforeMetrics = previousJoinableMetrics!
-    const shapesAcross = beforeMetrics.shapesAcrossSoftHyphen ??= new Map()
-    let result = shapesAcross.get(after)
-    if (result === undefined) {
-      const joined = before + after
-      const apart =
-        getCorrectedSegmentWidth(before, beforeMetrics, emojiCorrection) +
-        getCorrectedSegmentWidth(after, getSegmentMetrics(after, cache), emojiCorrection)
-      const together = getCorrectedSegmentWidth(joined, getSegmentMetrics(joined, cache), emojiCorrection)
-      result = apart - together > engineProfile.lineFitEpsilon
-      shapesAcross.set(after, result)
-    }
-    return result
+    const joined = before + after
+    const apart =
+      getCorrectedSegmentWidth(before, previousJoinableMetrics!, emojiCorrection) +
+      getCorrectedSegmentWidth(after, getSegmentMetrics(after, cache), emojiCorrection)
+    const together = getCorrectedSegmentWidth(joined, getSegmentMetrics(joined, cache), emojiCorrection)
+    return apart - together > engineProfile.lineFitEpsilon
   }
 
   function getEntryGeometry(
@@ -698,7 +690,6 @@ function measureAnalysis(
       const previousKind = mi > 0 ? analysis.kinds[mi - 1] : undefined
       const nextText = mi + 1 < analysis.len ? analysis.texts[mi + 1]! : ''
       const takesLetterSpacing = hasLetterSpacing && (
-        engineProfile.letterSpaceNextLine ||
         ((previousKind === 'text' || previousKind === 'glue') && needsComplexTextPath(analysis.texts[mi - 1]!)) ||
         (leadingCombiningMarkRe.test(nextText) && needsComplexTextPath(nextText))
       )
@@ -1044,7 +1035,6 @@ export function layoutWithLines(prepared: PreparedTextWithSegments, maxWidth: nu
 
 export function clearCache(): void {
   clearAnalysisCaches()
-  clearLineTextCaches()
   clearMeasurementCaches()
 }
 

--- a/src/line-break.ts
+++ b/src/line-break.ts
@@ -9,8 +9,6 @@ export type LineBreakCursor = {
 
 export type PreparedLineBreakData = {
   widths: number[]
-  lineEndFitAdvances: number[]
-  lineEndPaintAdvances: number[] // Painted contribution before terminal line-end letter-spacing
   kinds: SegmentBreakKind[]
   simpleLineWalkFastPath: boolean
   breakableFitAdvances: (number[] | null)[]
@@ -92,7 +90,7 @@ function getLineEndContribution(leadingSpacing: number, segmentContribution: num
   return segmentContribution === 0 ? 0 : leadingSpacing + segmentContribution
 }
 
-function getTabTrailingLetterSpacing(
+function getTrailingLetterSpacing(
   prepared: PreparedLineBreakData,
   segmentIndex: number,
 ): number {
@@ -104,38 +102,29 @@ function getTabTrailingLetterSpacing(
     : 0
 }
 
+// A line that ends after a whole segment charges its advance and the letter
+// spacing gap after it. Spaces and zero-width breaks hang, and zero-width text
+// owns no gap, though NEL does. The walker handles soft hyphens before this.
 function getWholeSegmentFitContribution(
   prepared: PreparedLineBreakData,
   kind: SegmentBreakKind,
+  breakAfter: boolean,
   segmentIndex: number,
   leadingSpacing: number,
   segmentWidth: number,
 ): number {
-  const segmentContribution = kind === 'tab'
-    ? segmentWidth + getTabTrailingLetterSpacing(prepared, segmentIndex)
-    : prepared.lineEndFitAdvances[segmentIndex]!
-  return getLineEndContribution(leadingSpacing, segmentContribution)
+  if (breakAfter ? kind !== 'tab' : segmentWidth === 0 && kind !== 'control') return 0
+  return getLineEndContribution(leadingSpacing, segmentWidth + getTrailingLetterSpacing(prepared, segmentIndex))
 }
 
-function getBreakOpportunityFitContribution(
-  prepared: PreparedLineBreakData,
-  kind: SegmentBreakKind,
-  segmentIndex: number,
-  leadingSpacing: number,
-): number {
-  const segmentContribution = kind === 'tab' ? 0 : prepared.lineEndFitAdvances[segmentIndex]!
-  return getLineEndContribution(leadingSpacing, segmentContribution)
-}
-
+// A line that ends after a collapsible space or a zero-width break paints none
+// of it. The walker handles soft hyphens before this.
 function getLineEndPaintContribution(
-  prepared: PreparedLineBreakData,
   kind: SegmentBreakKind,
-  segmentIndex: number,
   leadingSpacing: number,
   segmentWidth: number,
 ): number {
-  const segmentContribution = kind === 'tab' ? segmentWidth : prepared.lineEndPaintAdvances[segmentIndex]!
-  return getLineEndContribution(leadingSpacing, segmentContribution)
+  return kind === 'space' || kind === 'zero-width-break' ? 0 : getLineEndContribution(leadingSpacing, segmentWidth)
 }
 
 function getBreakableGraphemeAdvance(
@@ -681,10 +670,10 @@ function walkPreparedComplexLines(
     advance: number,
   ): void {
     if (!breakAfter) return
-    const fitAdvance = getBreakOpportunityFitContribution(prepared, kind, segmentIndex, leadingSpacing)
-    const paintAdvance = getLineEndPaintContribution(prepared, kind, segmentIndex, leadingSpacing, segmentWidth)
+    const paintAdvance = getLineEndPaintContribution(kind, leadingSpacing, segmentWidth)
     pendingBreakSegmentIndex = segmentIndex + 1
-    pendingBreakFitWidth = lineW - advance + fitAdvance
+    // The break segment hangs with the gap before it.
+    pendingBreakFitWidth = lineW - advance
     pendingBreakPaintWidth = lineW - advance + paintAdvance
     pendingBreakKind = kind
   }
@@ -818,7 +807,6 @@ function walkPreparedComplexLines(
           ? getTabAdvance(lineW + leadingSpacing, prepared.tabStopAdvance, engineProfile.skipNarrowTabStops ? prepared.tabStopAdvance / 16 : 0)
           : widths[i]!
         const advance = leadingSpacing + w
-        const fitAdvance = getWholeSegmentFitContribution(prepared, kind, i, leadingSpacing, w)
 
         if (kind === 'soft-hyphen' && startGraphemeIndex === 0) {
           if (hasContent) {
@@ -839,6 +827,7 @@ function walkPreparedComplexLines(
           continue
         }
 
+        const fitAdvance = getWholeSegmentFitContribution(prepared, kind, breakAfter, i, leadingSpacing, w)
         if (!hasContent) {
           if (startGraphemeIndex > 0) {
             const line = appendBreakableSegmentFrom(i, startGraphemeIndex)
@@ -873,12 +862,9 @@ function walkPreparedComplexLines(
             lineEndSegmentIndex = i - 1
             lineEndGraphemeIndex = 0
           }
-          const currentBreakFitWidth =
-            lineW + getBreakOpportunityFitContribution(prepared, kind, i, leadingSpacing)
-          const currentBreakPaintWidth =
-            lineW + getLineEndPaintContribution(prepared, kind, i, leadingSpacing, w)
-
-          if (breakAfter && currentBreakFitWidth <= fitLimit) {
+          // A break segment hangs with the gap before it.
+          if (breakAfter && lineW <= fitLimit) {
+            const currentBreakPaintWidth = lineW + getLineEndPaintContribution(kind, leadingSpacing, w)
             appendWholeSegment(i, advance)
             lineWidth = finishLine(i + 1, 0, currentBreakPaintWidth)
             break lineLoop

--- a/src/line-text.ts
+++ b/src/line-text.ts
@@ -2,7 +2,7 @@ import { getSharedGraphemeSegmenter } from './analysis.js'
 import { isDiscretionaryLineEnd } from './line-break.js'
 import type { PreparedTextWithSegments } from './layout.js'
 
-let sharedLineTextCaches = new WeakMap<PreparedTextWithSegments, Map<number, number[]>>()
+const sharedLineTextCaches = new WeakMap<PreparedTextWithSegments, Map<number, number[]>>()
 
 function getSegmentGraphemeOffsets(
   segmentIndex: number,
@@ -58,8 +58,4 @@ export function buildLineTextFromRange(
   }
 
   return isDiscretionaryLineEnd(prepared.kinds, endSegmentIndex, endGraphemeIndex) ? text + '-' : text
-}
-
-export function clearLineTextCaches(): void {
-  sharedLineTextCaches = new WeakMap<PreparedTextWithSegments, Map<number, number[]>>()
 }

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -92,8 +92,12 @@ export type EngineProfile = {
   // ordinary text for now: Blink joins Arabic across a soft hyphen that Pretext
   // measures as separate segments, which the break before NEL was hiding, and
   // release Gecko draws NEL with no advance while its Canvas measures a space.
-  // NEL control segments take letter spacing only where WebKit's complex text
-  // path spaces NEL. Blink spaces NEL outside cursive runs.
+  // WebKit's simple text path gives NEL no letter spacing, at either sign, and
+  // its complex path spaces it. A NEL control segment takes spacing after text
+  // or glue in WebKit's complex ranges, or before such text that starts with a
+  // combining mark. Preparation cannot see the page direction, so after complex
+  // text whose direction differs from the page's it keeps spacing Safari omits.
+  // Blink spaces NEL outside cursive runs.
   breakOnlyAfterNextLine: boolean
   // WebKit moves a tab to the following stop when less than half a space would
   // remain before the next one (FontCascade::tabWidth).

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -16,9 +16,6 @@ const entryContextProperties = ['font', 'direction', 'fontKerning', 'fontStretch
 export type SegmentMetrics = {
   width: number
   emojiCount?: number
-  // Per following piece across a soft hyphen: true when the joined text measures
-  // narrower than the two pieces apart.
-  shapesAcrossSoftHyphen?: Map<string, boolean>
   breakableFitMode?: BreakableFitMode
   breakableFitAdvances?: number[] | null
   entryGeometry?: {
@@ -95,12 +92,9 @@ export type EngineProfile = {
   // ordinary text for now: Blink joins Arabic across a soft hyphen that Pretext
   // measures as separate segments, which the break before NEL was hiding, and
   // release Gecko draws NEL with no advance while its Canvas measures a space.
+  // NEL control segments take letter spacing only where WebKit's complex text
+  // path spaces NEL. Blink spaces NEL outside cursive runs.
   breakOnlyAfterNextLine: boolean
-  // WebKit's simple text path replaces a control character's advance after
-  // applying letter spacing, so NEL takes none there, at either sign. Its
-  // complex path spaces NEL like other characters. Blink spaces NEL outside
-  // cursive runs.
-  letterSpaceNextLine: boolean
   // WebKit moves a tab to the following stop when less than half a space would
   // remain before the next one (FontCascade::tabWidth).
   skipNarrowTabStops: boolean
@@ -303,7 +297,6 @@ export function getEngineProfile(language: BreakLanguage = 'root'): EngineProfil
     letterSpaceDiscretionaryHyphen: engine !== 'blink',
     unfitHyphenRetreat: engine === 'blink' ? 'reduced-width' : 'none',
     breakOnlyAfterNextLine: engine === 'webkit',
-    letterSpaceNextLine: engine !== 'webkit',
     skipNarrowTabStops: engine === 'webkit',
     inlineItemBreaks: engine === 'blink' ? 'joined-text' : engine === 'webkit' ? 'item-text' : 'item-boundary',
   }

--- a/src/rich-inline.ts
+++ b/src/rich-inline.ts
@@ -652,6 +652,20 @@ export function prepareRichInline(items: RichInlineItem[]): PreparedRichInline {
   } as InternalPreparedRichInline
 }
 
+// Emits a fragment covering a whole item, from its start to its source end.
+function collectWholeItem(
+  collectFragment: RichInlineFragmentCollector | undefined,
+  itemIndex: number,
+  item: PreparedRichInlineItem,
+  gapBefore: number,
+  occupiedWidth: number,
+): void {
+  collectFragment?.(itemIndex, gapBefore, occupiedWidth, cloneCursor(EMPTY_LAYOUT_CURSOR), {
+    segmentIndex: item.prepared.segments.length,
+    graphemeIndex: 0,
+  })
+}
+
 function stepRichInlineLine(
   flow: InternalPreparedRichInline,
   maxWidth: number,
@@ -667,23 +681,16 @@ function stepRichInlineLine(
   let remainingWidth = safeWidth
   let itemIndex = cursor.itemIndex
 
+  // Every `continue` moves on to the start of the next item.
   lineLoop:
-  while (itemIndex < flow.items.length) {
+  for (; itemIndex < flow.items.length; itemIndex++, cursor.segmentIndex = 0, cursor.graphemeIndex = 0) {
     const item = flow.items[itemIndex]
-    if (item === undefined) {
-      itemIndex++
-      cursor.segmentIndex = 0
-      cursor.graphemeIndex = 0
-      continue
-    }
+    if (item === undefined) continue
     if (
       !isLineStartCursor(cursor) &&
       cursor.segmentIndex === item.prepared.segments.length &&
       cursor.graphemeIndex === 0
     ) {
-      itemIndex++
-      cursor.segmentIndex = 0
-      cursor.graphemeIndex = 0
       continue
     }
 
@@ -691,13 +698,7 @@ function stepRichInlineLine(
     // turning their mere presence into a line. Their prior layout behavior is
     // unchanged; a following line can still expose their consumed source.
     if (!item.establishesLine) {
-      collectFragment?.(itemIndex, 0, 0, cloneCursor(EMPTY_LAYOUT_CURSOR), {
-        segmentIndex: item.prepared.segments.length,
-        graphemeIndex: 0,
-      })
-      itemIndex++
-      cursor.segmentIndex = 0
-      cursor.graphemeIndex = 0
+      collectWholeItem(collectFragment, itemIndex, item, 0, 0)
       continue
     }
 
@@ -705,33 +706,16 @@ function stepRichInlineLine(
     const atItemStart = isLineStartCursor(cursor)
 
     if (item.break === 'never') {
-      if (!atItemStart) {
-        itemIndex++
-        cursor.segmentIndex = 0
-        cursor.graphemeIndex = 0
-        continue
-      }
+      if (!atItemStart) continue
 
       const occupiedWidth = item.naturalWidth + item.extraWidth
       const totalWidth = gapBefore + occupiedWidth
       if (hasContent && totalWidth > remainingWidth) break lineLoop
 
-      collectFragment?.(
-        itemIndex,
-        gapBefore,
-        occupiedWidth,
-        cloneCursor(EMPTY_LAYOUT_CURSOR),
-        {
-          segmentIndex: item.prepared.segments.length,
-          graphemeIndex: 0,
-        },
-      )
+      collectWholeItem(collectFragment, itemIndex, item, gapBefore, occupiedWidth)
       hasContent = true
       lineWidth += totalWidth
       remainingWidth = safeWidth - lineWidth
-      itemIndex++
-      cursor.segmentIndex = 0
-      cursor.graphemeIndex = 0
       continue
     }
 
@@ -755,22 +739,10 @@ function stepRichInlineLine(
           (isLineStartCursor(item.lastRunStart) && !(hasContent && item.breakBefore))
         )
       ) {
-        collectFragment?.(
-          itemIndex,
-          gapBefore,
-          item.naturalWidth + item.extraWidth,
-          cloneCursor(EMPTY_LAYOUT_CURSOR),
-          {
-            segmentIndex: item.prepared.segments.length,
-            graphemeIndex: 0,
-          },
-        )
+        collectWholeItem(collectFragment, itemIndex, item, gapBefore, item.naturalWidth + item.extraWidth)
         hasContent = true
         lineWidth += totalWidth
         remainingWidth = safeWidth - lineWidth
-        itemIndex++
-        cursor.segmentIndex = 0
-        cursor.graphemeIndex = 0
         continue
       }
     }
@@ -781,19 +753,11 @@ function stepRichInlineLine(
       graphemeIndex: cursor.graphemeIndex,
     }
     let lineWidthForItem = stepPreparedLineGeometry(item.prepared, lineEnd, availableWidth)
-    if (lineWidthForItem === null) {
-      itemIndex++
-      cursor.segmentIndex = 0
-      cursor.graphemeIndex = 0
-      continue
-    }
+    if (lineWidthForItem === null) continue
     if (
       cursor.segmentIndex === lineEnd.segmentIndex &&
       cursor.graphemeIndex === lineEnd.graphemeIndex
     ) {
-      itemIndex++
-      cursor.segmentIndex = 0
-      cursor.graphemeIndex = 0
       continue
     }
 
@@ -881,9 +845,6 @@ function stepRichInlineLine(
       lineEnd.segmentIndex === item.prepared.segments.length &&
       lineEnd.graphemeIndex === 0
     ) {
-      itemIndex++
-      cursor.segmentIndex = 0
-      cursor.graphemeIndex = 0
       continue
     }
 

--- a/tests/wrapping/VALIDATION.md
+++ b/tests/wrapping/VALIDATION.md
@@ -261,9 +261,8 @@ text or glue ends the line before that content. WebKit's simple text path gives
 NEL no letter spacing, so NEL takes spacing only next to complex text or before a
 combining mark. Safari also moves a `pre-wrap` tab to the following stop when
 less than half a space would remain before the next one. The profile fields
-`breakOnlyAfterNextLine`, `letterSpaceNextLine` and `skipNarrowTabStops` key on
-the layout engine; Chrome and Firefox keep NEL as ordinary text and the previous
-tab rule.
+`breakOnlyAfterNextLine` and `skipNarrowTabStops` key on the layout engine;
+Chrome and Firefox keep NEL as ordinary text and the previous tab rule.
 
 The installed gate ran this change on `daf13ac` against pinned `e5e66be`: Chrome
 153 through the Playwright transport, Safari 26.5.2 and Firefox 155 natively,

--- a/tests/wrapping/VALIDATION.md
+++ b/tests/wrapping/VALIDATION.md
@@ -52,6 +52,14 @@ and flat warm.
 `bun test` and `bun run check` pass. The baseline advances to `cc2328b`, and the
 ordinary snapshots were regenerated against it.
 
+Chrome and Safari benchmark snapshots were refreshed from this branch: three
+foreground runs each at DPR 2, visible and focused, with Chrome on the 2560x1440
+screen and Safari on the 2560x1440 screen (the parent branch's Safari runs used
+the 1440x2560 screen). Chrome reads `prepare()` at 8.50 ms (9.15 on the parent
+branch) and hot `layout()` at 0.0883 ms (0.0885); Safari reads 11.5 ms (11.0) and
+0.105 ms (0.105). Long-form corpus totals read 107.9 ms in Chrome (115.0) and 347
+ms in Safari (359).
+
 ## Small kana and ー in Chrome and Firefox
 
 This runtime change starts from main after #249. Chrome and Firefox now resolve

--- a/tests/wrapping/VALIDATION.md
+++ b/tests/wrapping/VALIDATION.md
@@ -17,6 +17,41 @@ All accuracy, letter-spacing and corpus result payloads are unchanged; refreshed
 snapshots change only provenance and environment records. Runtime sources and
 the baseline pin are unchanged, so no runtime benchmark was needed.
 
+## Smaller prepare state
+
+This change starts from main after #254 and leaves output unchanged. The
+`letterSpaceNextLine` profile field was false wherever it was read and is gone.
+The soft-hyphen shaping map and `clearLineTextCaches` duplicated caches that
+already exist. Prepared handles no longer keep per-segment `lineEndFitAdvances`
+and `lineEndPaintAdvances`: the complex line walker derives them from the width,
+kind and letter-spacing count each handle already holds. Those arrays were
+undocumented fields on the published `prepareWithSegments()` type. The hyphen,
+mandatory-break and CJK line-start sets now read the generated line-break class
+table, and `layoutNextLine()`, `layoutNextLineRange()` and the rich-inline item
+step share their duplicated advances. The library loses 110 lines net, and the
+core bundle about 316 B gzipped.
+
+Before the browsers, the Blink, WebKit, Gecko and Android profiles produced no
+output differences across 163 texts, about 1,956 handles and 11,736 rows each,
+with identical Canvas call counts. The derived advances matched the stored arrays
+in about 1.5 million checks per profile, and the numeric companion is unchanged.
+
+The installed gate ran against #250's pin `b4d9fd7`: Chrome 153 through the
+Playwright transport, Safari 26.5.2 and Firefox 155 natively, both directions.
+No leg fixes or loses a metric, and none has required failures, execution errors,
+or new API or rich failures.
+
+Interleaved V8 timings (Node 23, a fake canvas with a Chrome user agent, 31
+rounds, head against base) read cold `prepare()` over the long-form corpus 2.5%
+faster and warm 1.6% faster. `layout()` is 15% faster for pre-wrap, 7% faster
+with letter spacing and flat (+0.5%) on the simple path. Soft-hyphen-heavy text
+prepares 1.9% slower cold (10.0 ms against 9.85), because each soft hyphen now
+looks up its joined text in the segment metrics cache instead of the removed map,
+and flat warm.
+
+`bun test` and `bun run check` pass. The baseline advances to `cc2328b`, and the
+ordinary snapshots were regenerated against it.
+
 ## Small kana and ー in Chrome and Firefox
 
 This runtime change starts from main after #249. Chrome and Firefox now resolve

--- a/tests/wrapping/baseline.json
+++ b/tests/wrapping/baseline.json
@@ -1,4 +1,4 @@
 {
-  "revision": "b4d9fd7beb475c7241e9b81aa2b56562346ddb85",
+  "revision": "cc2328bdd9f323e13a336cab834bea842cbe7d6d",
   "description": "Reviewed boundary, rich-inline, shared complex-walker, leading-ZWSP, exclamation-break, figure-space glue, pair-table gap, CJK closing-bracket, Safari line-edge kerning, WebKit engine routing, segment-break removal and Blink soft-hyphen retreat fixes. The runner measures this source and every candidate against the same fresh browser observations; existing mismatches remain observations, never expected answers."
 }

--- a/tests/wrapping/entry-geometry.test.ts
+++ b/tests/wrapping/entry-geometry.test.ts
@@ -38,7 +38,7 @@ test('fresh entry geometry survives copied public range cursors without layout m
   // A numeric fixture keeps this source/cursor invariant independent of a
   // Canvas backend. It is not a claim about native control or mark advances.
   const prepared = {
-    widths: [19], lineEndFitAdvances: [19], lineEndPaintAdvances: [19], kinds: ['text'],
+    widths: [19], kinds: ['text'],
     simpleLineWalkFastPath: false, segLevels: null, breakableFitAdvances: [advances],
     breakablePreferredBreaks: [null], entryGeometry: [entry], letterSpacing: 0,
     spacingGraphemeCounts: [], discretionaryHyphenWidth: 4, tabStopAdvance: 32,


### PR DESCRIPTION
Output-neutral simplifications of prepare state, one commit per batch:

1. **Drop a constant profile field and two redundant caches.** `EngineProfile.letterSpaceNextLine` was always false wherever it was read. The soft-hyphen shaping memo and `clearLineTextCaches` duplicated caches that already exist.
2. **Derive line-end fit and paint advances** instead of storing two per-segment arrays on every prepared handle. Handles for virtualized lists hold less memory.
3. **Derive the hyphen, mandatory-break and CJK line-start sets from the generated class table** instead of hand-kept sets.
4. **Share the streamed line step and the rich-inline item advance** between the APIs that duplicated them.

Two follow-up commits sync the NEL and kinsoku notes.

**Equivalence:**
- Blink, WebKit, Gecko and Android profiles: 0 output differences across 163 texts, about 1,956 handles and 11,736 rows each, with identical Canvas call counts.
- Batch 2's derived advances were checked against the stored arrays in about 1.5 million checks per profile.
- The numeric companion is unchanged.
- `bun run check` and `bun test` pass.

**Published type:** batch 2 removes the undocumented internal `lineEndFitAdvances` and `lineEndPaintAdvances` fields from the TypeScript type of `prepareWithSegments()` results.

**Size:** net −110 lines, and about −316 B gzipped on the core bundle.

**V8 timings.** Node 23 with a fake canvas and a Chrome user agent, 31 interleaved rounds, head against base:
- **Cold `prepare()`:** 2.5% faster over the long-form corpus texts.
- **Warm `prepare()`:** 1.6% faster over the same texts.
- **`layout()`:** pre-wrap 15% faster, letter-spaced 7% faster, simple path flat (+0.5%).
- **Soft-hyphen-heavy text:** 1.9% slower cold (10.0 ms against 9.85) and flat warm. That's the removed soft-hyphen memo.

**Installed gate:** full suite in Chrome, Safari and Firefox, both directions: no metric fixed or lost, and no required failures, execution errors, or new API or rich failures. The refreshed snapshots change only provenance and environment records.

**Benchmarks:**
- **Chrome:** `prepare()` 8.50 ms (9.15 on the parent branch), `layout()` 0.0883 ms (0.0885), long-form corpus total 107.9 ms (115.0).
- **Safari:** 11.5 ms (11.0), 0.105 ms (0.105), and 347 ms (359). These runs used a different screen from the parent's.
